### PR TITLE
Rakuten api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,5 @@
 
 /node_modules
 /yarn-error.log
-
+/.env
 .byebug_history

--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,5 @@
 
 /node_modules
 /yarn-error.log
-/.env
+.env
 .byebug_history

--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,8 @@ gem 'devise-bootstrap-views'
 gem 'dotenv-rails'
 # 画像をリサイズ
 gem 'mini_magick'
+# 楽天Webサービス
+gem 'rakuten_web_service'
 # Use Uglifier as compressor for JavaScript assets
 gem 'uglifier', '>= 1.3.0'
 # See https://github.com/rails/execjs#readme for more supported runtimes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -154,6 +154,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (12.3.1)
+    rakuten_web_service (1.9.1)
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
@@ -231,6 +232,7 @@ DEPENDENCIES
   omniauth-twitter
   puma (~> 3.7)
   rails (~> 5.1.6)
+  rakuten_web_service
   sass-rails (~> 5.0)
   selenium-webdriver
   spring

--- a/README.md
+++ b/README.md
@@ -1,24 +1,19 @@
 # README
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+## 日本酒を種類、詳細などを見れ、こだわりの日本酒が見つけられるサービス
+日本酒の種類、酒造会社、地域などはWikiを参照
+https://ja.wikipedia.org/wiki/%E6%97%A5%E6%9C%AC%E9%85%92%E3%81%AE%E9%8A%98%E6%9F%84%E4%B8%80%E8%A6%A7
+（なお、本醸造酒、純米酒などの区別については今回は区別は特にしないものとする
+  ※今回は..）
 
-Things you may want to cover:
+### 使用するAPI
+- RakutenWebService - (URL)[https://webservice.rakuten.co.jp/api/ichibaitemsearch/]
+- Amazon アソシエイト - (URL)[https://affiliate.amazon.co.jp/assoc_credentials/home]
+※どちらも画像の表示の為
 
-* Ruby version
+### 言語
+Ruby on Rails
 
-* System dependencies
-
-* Configuration
-
-* Database creation
-
-* Database initialization
-
-* How to run the test suite
-
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...
+### その他
+スタイルは Bootstrapを使用
+D3.jsを採用するかも..?

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,6 +10,7 @@
 // Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
 // about supported directives.
 //
-//= require rails-ujs
-//= require turbolinks
-//= require_tree .
+//= require jquery3
+//= require jquery_ujs
+//= require popper
+//= require bootstrap-sprockets

--- a/app/assets/javascripts/post.coffee
+++ b/app/assets/javascripts/post.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/top.coffee
+++ b/app/assets/javascripts/top.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -10,6 +10,9 @@
  * files in this directory. Styles in this file should be added after the last require_* statement.
  * It is generally better to create a new file per style scope.
  *
- *= require_tree .
- *= require_self
  */
+@import "bootstrap";
+
+.container {
+  margin: 20px;
+}

--- a/app/assets/stylesheets/post.scss
+++ b/app/assets/stylesheets/post.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Post controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/top.scss
+++ b/app/assets/stylesheets/top.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the top controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/top.scss
+++ b/app/assets/stylesheets/top.scss
@@ -1,3 +1,4 @@
 // Place all the styles related to the top controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
+@import "bootstrap";

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -1,0 +1,11 @@
+class OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  def twitter
+    @user = User.from_omniauth(request.env["omniauth.auth"].except("extra"))
+    if @user.persisted?
+      sign_in_and_redirect @user
+    else
+      session["devise.user_attributes"] = @user.attributes
+      redirect_to new_user_registration_url
+    end
+  end
+end

--- a/app/controllers/post_controller.rb
+++ b/app/controllers/post_controller.rb
@@ -1,0 +1,11 @@
+class PostController < ApplicationController
+  def index
+    @post = Post.all
+  end
+
+  def show
+  end
+
+  def edit
+  end
+end

--- a/app/controllers/post_controller.rb
+++ b/app/controllers/post_controller.rb
@@ -8,4 +8,15 @@ class PostController < ApplicationController
 
   def edit
   end
+
+  def update
+  end
+
+  def destroy
+  end
+
+  private
+
+  def post_params
+  end
 end

--- a/app/controllers/top_controller.rb
+++ b/app/controllers/top_controller.rb
@@ -1,0 +1,4 @@
+class TopController < ApplicationController
+  def index
+  end
+end

--- a/app/controllers/top_controller.rb
+++ b/app/controllers/top_controller.rb
@@ -6,6 +6,5 @@ class TopController < ApplicationController
             imageFlag: 1,
             hits: 2,
           })
-
   end
 end

--- a/app/controllers/top_controller.rb
+++ b/app/controllers/top_controller.rb
@@ -1,4 +1,11 @@
 class TopController < ApplicationController
   def index
+
+    @results = RakutenWebService::Ichiba::Item.search({
+            keyword: '獺祭',
+            imageFlag: 1,
+            hits: 2,
+          })
+
   end
 end

--- a/app/helpers/omniauth_callbacks_helper.rb
+++ b/app/helpers/omniauth_callbacks_helper.rb
@@ -1,0 +1,2 @@
+module OmniauthCallbacksHelper
+end

--- a/app/helpers/post_helper.rb
+++ b/app/helpers/post_helper.rb
@@ -1,0 +1,2 @@
+module PostHelper
+end

--- a/app/helpers/top_helper.rb
+++ b/app/helpers/top_helper.rb
@@ -1,0 +1,2 @@
+module TopHelper
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,0 +1,2 @@
+class Post < ApplicationRecord
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,27 @@
+class User < ApplicationRecord
+  # Include default devise modules. Others available are:
+  # :confirmable, :lockable, :timeoutable and :omniauthable
+  devise :database_authenticatable, :registerable,
+         :rememberable, :trackable, :validatable,
+         :omniauthable, omniauth_providers: [:twitter]
+
+  def self.from_omniauth(auth)
+    find_or_create_by(provider: auth["provider"], uid: auth["uid"]) do |user|
+      user.provider = auth["provider"]
+      user.uid = auth["uid"]
+      user.name = auth["info"]["nickname"]
+      user.password = "123456"
+    end
+  end
+
+  def self.new_with_session(params, session)
+    if session["devise.user_attributes"]
+      new(session["devise.user_attributes"]) do |user|
+        user.attributes = params
+      end
+    else
+      super
+    end
+  end
+
+end

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,0 +1,18 @@
+<%= bootstrap_devise_error_messages! %>
+<div class="panel panel-default devise-bs">
+  <div class="panel-heading">
+    <h4><%= t('.resend_confirmation_instructions', default: 'Resend confirmation instructions') %></h4>
+  </div>
+  <div class="panel-body">
+    <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post, role: 'form' }) do |f| %>
+      <div class="form-group">
+        <%= f.label :email %>
+        <%= f.email_field :email, autofocus: true, class: "form-control"  %>
+      </div>
+
+      <%= f.submit t('.resend_confirmation_instructions', default: 'Resend confirmation instructions'), class: 'btn btn-primary' %>
+    <% end %>
+  </div>
+</div>
+
+<%= render 'devise/shared/links' %>

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,0 +1,6 @@
+<p><%= t('.greeting', recipient: @resource.email, default: "Welcome #{@resource.email}!") %></p>
+
+<p><%= t('.instruction', default: 'You can confirm your account email through the link below:') %></p>
+
+<p><%= link_to t('.action', default: 'Confirm my account'),
+         confirmation_url(@resource, confirmation_token: @token, locale: I18n.locale) %></p>

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,0 +1,8 @@
+<p><%= t('.greeting', recipient: @resource.email, default: "Hello #{@resource.email}!") %></p>
+
+<p><%= t('.instruction', default: 'Someone has requested a link to change your password, and you can do this through the link below.') %></p>
+
+<p><%= link_to t('.action', default: 'Change my password'), edit_password_url(@resource, reset_password_token: @token, locale: I18n.locale) %></p>
+
+<p><%= t('.instruction_2', default: "If you didn't request this, please ignore this email.") %></p>
+<p><%= t('.instruction_3', default: "Your password won't change until you access the link above and create a new one.") %></p>

--- a/app/views/devise/mailer/unlock_instructions.html.erb
+++ b/app/views/devise/mailer/unlock_instructions.html.erb
@@ -1,0 +1,7 @@
+<p><%= t('.greeting', recipient: @resource.email, default: "Hello #{@resource.email}!") %></p>
+
+<p><%= t('.message', default: 'Your account has been locked due to an excessive amount of unsuccessful sign in attempts.') %></p>
+
+<p><%= t('.instruction', default: 'Click the link below to unlock your account:') %></p>
+
+<p><%= link_to t('.action', default: 'Unlock my account'), unlock_url(@resource, unlock_token: @resource.unlock_token, locale: I18n.locale) %></p>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,0 +1,24 @@
+<%= bootstrap_devise_error_messages! %>
+<div class="panel panel-default devise-bs">
+  <div class="panel-heading">
+    <h4><%= t('.change_your_password', default: 'Change your password') %></h4>
+  </div>
+  <div class="panel-body">
+    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put, role: 'form' }) do |f| %>
+      <%= f.hidden_field :reset_password_token %>
+
+      <div class="form-group">
+        <%= f.label :password, t('.new_password', default: 'New password') %>
+        <%= f.password_field :password, autofocus: true, class: 'form-control'  %>
+      </div>
+
+      <div class="form-group">
+        <%= f.label :password_confirmation, t('.confirm_new_password', default: 'Confirm new password') %>
+        <%= f.password_field :password_confirmation, class: 'form-control'  %>
+      </div>
+
+      <%= f.submit t('.change_my_password', default: 'Change my password'), class: 'btn btn-primary' %>
+    <% end %>
+  </div>
+</div>
+<%= render 'devise/shared/links' %>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,0 +1,17 @@
+<%= bootstrap_devise_error_messages! %>
+<div class="panel panel-default devise-bs">
+  <div class="panel-heading">
+    <h4><%= t('.forgot_your_password', default: 'Forgot your password?') %></h4>
+  </div>
+  <div class="panel-body">
+    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, role: "form" }) do |f| %>
+      <div class="form-group">
+        <%= f.label :email %>
+        <%= f.email_field :email, autofocus: true, class: 'form-control' %>
+      </div>
+
+      <%= f.submit t('.send_me_reset_password_instructions', default: 'Send me reset password instructions'), class: 'btn btn-primary' %>
+    <% end %>
+  </div>
+</div>
+<%= render 'devise/shared/links' %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,0 +1,31 @@
+<%= bootstrap_devise_error_messages! %>
+<div class="panel panel-default devise-bs">
+  <div class="panel-heading">
+    <h4><%= t('.title', resource: resource_class.model_name.human , default: "Edit #{resource_name.to_s.humanize}") %></h4>
+  </div>
+  <div class="panel-body">
+    <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+      <div class="form-group">
+        <%= f.label :email %>
+        <%= f.email_field :email, autofocus: true, class: 'form-control' %>
+      </div>
+      <div class="form-group">
+        <%= f.label :password %> <i>(<%= t('.leave_blank_if_you_don_t_want_to_change_it', default: "leave blank if you don't want to change it") %>)</i>
+        <%= f.password_field :password, autocomplete: "off", class: 'form-control' %>
+      </div>
+      <div class="form-group">
+        <%= f.label :password_confirmation %>
+        <%= f.password_field :password_confirmation, class: 'form-control'  %>
+      </div>
+      <div class="form-group">
+        <%= f.label :current_password %> <i>(<%= t('.we_need_your_current_password_to_confirm_your_changes', default: 'we need your current password to confirm your changes') %>)</i>
+        <%= f.password_field :current_password, class: 'form-control' %>
+      </div>
+      <%= f.submit t('.update', default: 'Update'), class: 'btn btn-primary' %>
+    <% end %>
+  </div>
+</div>
+
+<p><%= t('.unhappy', default: 'Unhappy') %>? <%= link_to t('.cancel_my_account', default: 'Cancel my account'), registration_path(resource_name), data: { confirm: t('.are_you_sure', default: "Are you sure?") }, method: :delete %>.</p>
+
+<%= link_to t('.back', default: 'Back'), :back %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,32 +1,36 @@
 <%= bootstrap_devise_error_messages! %>
-<div class="panel panel-default devise-bs">
-  <div class="panel-heading">
-    <h4><%= t('.title', resource: resource_class.model_name.human , default: "Edit #{resource_name.to_s.humanize}") %></h4>
-  </div>
-  <div class="panel-body">
-    <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-      <div class="form-group">
-        <%= f.label :email %>
-        <%= f.email_field :email, autofocus: true, class: 'form-control' %>
+<div class="row">
+  <div class="col-md-8 col-md-offset-2">
+    <div class="panel panel-default devise-bs">
+      <div class="panel-heading">
+        <h4><%= t('.title', resource: resource_class.model_name.human , default: "Edit #{resource_name.to_s.humanize}") %></h4>
       </div>
-      <div class="form-group">
-        <%= f.label :name %>
-        <%= f.email_field :name, autofocus: true, class: 'form-control' %>
+      <div class="panel-body">
+        <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+          <div class="form-group">
+            <%= f.label :email %>
+            <%= f.email_field :email, autofocus: true, class: 'form-control' %>
+          </div>
+          <div class="form-group">
+            <%= f.label :name %>
+            <%= f.email_field :name, autofocus: true, class: 'form-control' %>
+          </div>
+          <div class="form-group">
+            <%= f.label :password %> <i>(<%= t('.leave_blank_if_you_don_t_want_to_change_it', default: "leave blank if you don't want to change it") %>)</i>
+            <%= f.password_field :password, autocomplete: "off", class: 'form-control' %>
+          </div>
+          <div class="form-group">
+            <%= f.label :password_confirmation %>
+            <%= f.password_field :password_confirmation, class: 'form-control'  %>
+          </div>
+          <div class="form-group">
+            <%= f.label :current_password %> <i>(<%= t('.we_need_your_current_password_to_confirm_your_changes', default: 'we need your current password to confirm your changes') %>)</i>
+            <%= f.password_field :current_password, class: 'form-control' %>
+          </div>
+          <%= f.submit t('.update', default: 'Update'), class: 'btn btn-primary' %>
+        <% end %>
       </div>
-      <div class="form-group">
-        <%= f.label :password %> <i>(<%= t('.leave_blank_if_you_don_t_want_to_change_it', default: "leave blank if you don't want to change it") %>)</i>
-        <%= f.password_field :password, autocomplete: "off", class: 'form-control' %>
-      </div>
-      <div class="form-group">
-        <%= f.label :password_confirmation %>
-        <%= f.password_field :password_confirmation, class: 'form-control'  %>
-      </div>
-      <div class="form-group">
-        <%= f.label :current_password %> <i>(<%= t('.we_need_your_current_password_to_confirm_your_changes', default: 'we need your current password to confirm your changes') %>)</i>
-        <%= f.password_field :current_password, class: 'form-control' %>
-      </div>
-      <%= f.submit t('.update', default: 'Update'), class: 'btn btn-primary' %>
-    <% end %>
+    </div>
   </div>
 </div>
 

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -10,6 +10,10 @@
         <%= f.email_field :email, autofocus: true, class: 'form-control' %>
       </div>
       <div class="form-group">
+        <%= f.label :name %>
+        <%= f.email_field :name, autofocus: true, class: 'form-control' %>
+      </div>
+      <div class="form-group">
         <%= f.label :password %> <i>(<%= t('.leave_blank_if_you_don_t_want_to_change_it', default: "leave blank if you don't want to change it") %>)</i>
         <%= f.password_field :password, autocomplete: "off", class: 'form-control' %>
       </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,0 +1,24 @@
+<%= bootstrap_devise_error_messages! %>
+<div class="panel panel-default devise-bs">
+  <div class="panel-heading">
+    <h4><%= t('.sign_up', default: 'Sign up') %></h4>
+  </div>
+  <div class="panel-body">
+    <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { role: 'form' }) do |f| %>
+      <div class="form-group">
+        <%= f.label :email %>
+        <%= f.email_field :email, autofocus: true, class: 'form-control' %>
+      </div>
+      <div class="form-group">
+        <%= f.label :password %>
+        <%= f.password_field :password, class: 'form-control' %>
+      </div>
+      <div class="form-group">
+        <%= f.label :password_confirmation %>
+        <%= f.password_field :password_confirmation, class: 'form-control' %>
+      </div>
+      <%= f.submit t('.sign_up', default: 'Sign up'), class: 'btn btn-primary' %>
+    <% end %>
+  </div>
+</div>
+<%= render 'devise/shared/links' %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,24 +1,28 @@
 <%= bootstrap_devise_error_messages! %>
-<div class="panel panel-default devise-bs">
-  <div class="panel-heading">
-    <h4><%= t('.sign_up', default: 'Sign up') %></h4>
-  </div>
-  <div class="panel-body">
-    <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { role: 'form' }) do |f| %>
-      <div class="form-group">
-        <%= f.label :email %>
-        <%= f.email_field :email, autofocus: true, class: 'form-control' %>
+<div class="row">
+  <div class="col-md-8 col-md-offset-2">
+    <div class="panel panel-default devise-bs">
+      <div class="panel-heading">
+        <h4><%= t('.sign_up', default: 'Sign up') %></h4>
       </div>
-      <div class="form-group">
-        <%= f.label :password %>
-        <%= f.password_field :password, class: 'form-control' %>
+      <div class="panel-body">
+        <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { role: 'form' }) do |f| %>
+          <div class="form-group">
+            <%= f.label :email %>
+            <%= f.email_field :email, autofocus: true, class: 'form-control' %>
+          </div>
+          <div class="form-group">
+            <%= f.label :password %>
+            <%= f.password_field :password, class: 'form-control' %>
+          </div>
+          <div class="form-group">
+            <%= f.label :password_confirmation %>
+            <%= f.password_field :password_confirmation, class: 'form-control' %>
+          </div>
+          <%= f.submit t('.sign_up', default: 'Sign up'), class: 'btn btn-primary' %>
+        <% end %>
       </div>
-      <div class="form-group">
-        <%= f.label :password_confirmation %>
-        <%= f.password_field :password_confirmation, class: 'form-control' %>
-      </div>
-      <%= f.submit t('.sign_up', default: 'Sign up'), class: 'btn btn-primary' %>
-    <% end %>
+    </div>
+    <%= render 'devise/shared/links' %>
   </div>
 </div>
-<%= render 'devise/shared/links' %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,0 +1,26 @@
+<div class="panel panel-default devise-bs">
+  <div class="panel-heading">
+    <h4><%= t('.sign_in', default: 'Sign in') %></h4>
+  </div>
+  <div class="panel-body">
+    <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { role: 'form' }) do |f| %>
+      <div class="form-group">
+        <%= f.label :email %>
+        <%= f.email_field :email, autofocus: true, class: 'form-control' %>
+      </div>
+      <div class="form-group">
+        <%= f.label :password %>
+        <%= f.password_field :password, autocomplete: 'off', class: 'form-control' %>
+      </div>
+      <% if devise_mapping.rememberable? %>
+        <div class="checkbox">
+          <%= f.label :remember_me do %>
+            <%= f.check_box :remember_me %> <%= t('.remember_me', default: 'Remember me') %>
+          <% end %>
+        </div>
+      <% end %>
+      <%= f.submit  t('.sign_in', default: 'Sign in'), class: 'btn btn-primary' %>
+    <% end %>
+  </div>
+</div>
+<%= render 'devise/shared/links' %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,26 +1,30 @@
-<div class="panel panel-default devise-bs">
-  <div class="panel-heading">
-    <h4><%= t('.sign_in', default: 'Sign in') %></h4>
-  </div>
-  <div class="panel-body">
-    <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { role: 'form' }) do |f| %>
-      <div class="form-group">
-        <%= f.label :email %>
-        <%= f.email_field :email, autofocus: true, class: 'form-control' %>
+<div class="row">
+  <div class="col-md-8 col-md-offset-2">
+    <div class="panel panel-default devise-bs">
+      <div class="panel-heading">
+        <h4><%= t('.sign_in', default: 'Sign in') %></h4>
       </div>
-      <div class="form-group">
-        <%= f.label :password %>
-        <%= f.password_field :password, autocomplete: 'off', class: 'form-control' %>
-      </div>
-      <% if devise_mapping.rememberable? %>
-        <div class="checkbox">
-          <%= f.label :remember_me do %>
-            <%= f.check_box :remember_me %> <%= t('.remember_me', default: 'Remember me') %>
+      <div class="panel-body">
+        <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { role: 'form' }) do |f| %>
+          <div class="form-group">
+            <%= f.label :email %>
+            <%= f.email_field :email, autofocus: true, class: 'form-control' %>
+          </div>
+          <div class="form-group">
+            <%= f.label :password %>
+            <%= f.password_field :password, autocomplete: 'off', class: 'form-control' %>
+          </div>
+          <% if devise_mapping.rememberable? %>
+            <div class="checkbox">
+              <%= f.label :remember_me do %>
+                <%= f.check_box :remember_me %> <%= t('remember_me', default: 'Remember me') %>
+              <% end %>
+            </div>
           <% end %>
-        </div>
-      <% end %>
-      <%= f.submit  t('.sign_in', default: 'Sign in'), class: 'btn btn-primary' %>
-    <% end %>
+          <%= f.submit  t('.sign_in', default: 'Sign in'), class: 'btn btn-primary' %>
+        <% end %>
+      </div>
+    </div>
+    <%= render 'devise/shared/links' %>
   </div>
 </div>
-<%= render 'devise/shared/links' %>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,0 +1,25 @@
+<% if controller_name != 'sessions' %>
+  <%= link_to t('.sign_in', default: 'Sign in'), new_session_path(resource_name) %><br />
+<% end %>
+
+<% if devise_mapping.registerable? && controller_name != 'registrations' %>
+  <%= link_to t('.sign_up', default: 'Sign up'), new_registration_path(resource_name) %><br />
+<% end %>
+
+<% if devise_mapping.recoverable? && controller_name != 'passwords' %>
+  <%= link_to t('.forgot_your_password', default: 'Forgot your password?'), new_password_path(resource_name) %><br />
+<% end %>
+
+<% if devise_mapping.confirmable? && controller_name != 'confirmations' %>
+  <%= link_to t('.didn_t_receive_confirmation_instructions', default: "Didn't receive confirmation instructions?"), new_confirmation_path(resource_name) %><br />
+<% end %>
+
+<% if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
+  <%= link_to t('.didn_t_receive_unlock_instructions', default: "Didn't receive unlock instructions?"), new_unlock_path(resource_name) %><br />
+<% end %>
+
+<% if devise_mapping.omniauthable? %>
+  <% resource_class.omniauth_providers.each do |provider| %>
+  <%= link_to t('.sign_in_with_provider', provider: provider.to_s.titleize, default: "Sign in with #{provider.to_s.titleize}"), omniauth_authorize_path(resource_name, provider) %><br />
+  <% end %>
+<% end %>

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -1,0 +1,16 @@
+<%= bootstrap_devise_error_messages! %>
+<div class="panel panel-default devise-bs">
+  <div class="panel-heading">
+    <h4><%= t('.resend_unlock_instructions', default: 'Resend unlock instructions') %></h4>
+  </div>
+  <div class="panel-body">
+    <%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post, html: { role: "form" } }) do |f| %>
+      <div class="form-group">
+        <%= f.label :email %>
+        <%= f.email_field :email, autofocus: true, class: 'form-control' %>
+      </div>
+      <%= f.submit t('.resend_unlock_instructions', default: 'Resend unlock instructions'), class: 'btn btn-primary'%>
+    <% end %>
+  </div>
+</div>
+<%= render 'devise/shared/links' %>

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,0 +1,15 @@
+<% flash.each do |message_type, message| %>
+  <% if notice %>
+  <div class="alert alert-info">
+    <%= notice %>
+  </div>
+  <% elsif alert %>
+  <div class="alert alert-success">
+    <%= alert %>
+  </div>
+  <% else %>
+  <div class="alert alert-<%= message_type %>">
+    <%= message %>
+  </div>
+  <% end %>
+<% end %>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -1,0 +1,23 @@
+<!-- <nav class="navbar navbar-expand-lg navbar-light bg-light">
+  <%= link_to "MaPhoMe", root_path, class: 'navbar-brand' %>
+  <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+    <span class="navbar-toggler-icon"></span>
+  </button>
+
+  <div class="collapse navbar-collapse" id="navbarSupportedContent">
+    <ul class="navbar-nav mr-auto">
+      <% if user_signed_in? %>
+        <li class="nav-item"><%= link_to "プロフィール", edit_user_registration_path, class: 'nav-link' %></li>
+        <li class="nav-item"><%= link_to "探す","#", class: 'nav-link' %></li>
+        <% if Rails.env.development? %>
+          <li class="nav-item"><%= link_to "メール", letter_opener_web_path, class: 'nav-link' %></li>
+        <% end %>
+        <li class="divide, class: 'nav-link'r"></li>
+        <li class="nav-item"><%= link_to "ログアウト", destroy_user_session_path, method: :delete, class: 'nav-link' %></li>
+      <% else %>
+        <li class="nav-item"><%= link_to '新規登録', new_user_registration_path, class: 'nav-link' %></li>
+        <li class="nav-item"><%= link_to 'ログイン', new_user_session_path , class: 'nav-link' %></li>
+      <% end %>
+    </ul>
+  </div>
+</nav> -->

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -1,4 +1,4 @@
-<!-- <nav class="navbar navbar-expand-lg navbar-light bg-light">
+<nav class="navbar navbar-expand-lg navbar-light bg-light">
   <%= link_to "MaPhoMe", root_path, class: 'navbar-brand' %>
   <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>
@@ -10,7 +10,7 @@
         <li class="nav-item"><%= link_to "プロフィール", edit_user_registration_path, class: 'nav-link' %></li>
         <li class="nav-item"><%= link_to "探す","#", class: 'nav-link' %></li>
         <% if Rails.env.development? %>
-          <li class="nav-item"><%= link_to "メール", letter_opener_web_path, class: 'nav-link' %></li>
+          <li class="nav-item"><%= link_to "メール", "#", class: 'nav-link' %></li>
         <% end %>
         <li class="divide, class: 'nav-link'r"></li>
         <li class="nav-item"><%= link_to "ログアウト", destroy_user_session_path, method: :delete, class: 'nav-link' %></li>
@@ -20,4 +20,4 @@
       <% end %>
     </ul>
   </div>
-</nav> -->
+</nav>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,10 @@
   </head>
 
   <body>
-    <%= yield %>
+    <%= render 'layouts/navbar' %>
+    <div class="container">
+      <%= render 'layouts/flash' %>
+      <%= yield %>
+    </div>
   </body>
 </html>

--- a/app/views/post/edit.html.erb
+++ b/app/views/post/edit.html.erb
@@ -1,0 +1,2 @@
+<h1>Post#edit</h1>
+<p>Find me in app/views/post/edit.html.erb</p>

--- a/app/views/post/index.html.erb
+++ b/app/views/post/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Post#index</h1>
+<p>Find me in app/views/post/index.html.erb</p>

--- a/app/views/post/show.html.erb
+++ b/app/views/post/show.html.erb
@@ -1,0 +1,2 @@
+<h1>Post#show</h1>
+<p>Find me in app/views/post/show.html.erb</p>

--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Top#index</h1>
+<p>Find me in app/views/top/index.html.erb</p>

--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -12,9 +12,9 @@
   <p><%= result['itemPrice'] %></p>
   <p><a href="<%= result['itemUrl'] %>"><%= result['itemUrl'] %></a></p>
   <% result['smallImageUrls'].each do |result| %>
-    <p><%= image_tag result %></p>
+    <%= image_tag result %>
   <% end %>
   <% result['mediumImageUrls'].each do |result| %>
-    <p><%= image_tag result %></p>
-  <% end %>
+    <%= image_tag result %>
+  <% end %><tr>
 <% end %>

--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -1,2 +1,20 @@
+<style>
+  img {
+    height: 100%;
+    max-width: 100%;
+  }
+</style>
 <h1>Top#index</h1>
 <p>Find me in app/views/top/index.html.erb</p>
+<%= @results.each do |result| %>
+  <p><%= result['itemName'] %></p>
+  <p><%= result['catchcopy'] %></p>
+  <p><%= result['itemPrice'] %></p>
+  <p><a href="<%= result['itemUrl'] %>"><%= result['itemUrl'] %></a></p>
+  <% result['smallImageUrls'].each do |result| %>
+    <p><%= image_tag result %></p>
+  <% end %>
+  <% result['mediumImageUrls'].each do |result| %>
+    <p><%= image_tag result %></p>
+  <% end %>
+<% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,9 +10,14 @@ module SakeMaker
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.1
-
+    # 日本語化
+    config.i18n.default_locale = :ja
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
+    config.time_zone = 'Tokyo'
+    # Don't generate system test files.
+    config.generators.system_tests = nil
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -28,8 +28,8 @@ Rails.application.configure do
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
-
   config.action_mailer.perform_caching = false
+  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,0 +1,283 @@
+# frozen_string_literal: true
+
+# Use this hook to configure devise mailer, warden hooks and so forth.
+# Many of these configuration options can be set straight in your model.
+Devise.setup do |config|
+  # The secret key used by Devise. Devise uses this key to generate
+  # random tokens. Changing this key will render invalid all existing
+  # confirmation, reset password and unlock tokens in the database.
+  # Devise will use the `secret_key_base` as its `secret_key`
+  # by default. You can change it below and use your own secret key.
+  # config.secret_key = '330bf1990cae612411a8a585e505bef9216111f8f91be0dccbe774a560cbb22e55de3396004ffd15e180021f6f2dc3b0109cb62b1c0dd2388c78eec22c241514'
+  
+  # ==> Controller configuration
+  # Configure the parent class to the devise controllers.
+  # config.parent_controller = 'DeviseController'
+
+  # ==> Mailer Configuration
+  # Configure the e-mail address which will be shown in Devise::Mailer,
+  # note that it will be overwritten if you use your own mailer class
+  # with default "from" parameter.
+  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+
+  # Configure the class responsible to send e-mails.
+  # config.mailer = 'Devise::Mailer'
+
+  # Configure the parent class responsible to send e-mails.
+  # config.parent_mailer = 'ActionMailer::Base'
+
+  # ==> ORM configuration
+  # Load and configure the ORM. Supports :active_record (default) and
+  # :mongoid (bson_ext recommended) by default. Other ORMs may be
+  # available as additional gems.
+  require 'devise/orm/active_record'
+
+  # ==> Configuration for any authentication mechanism
+  # Configure which keys are used when authenticating a user. The default is
+  # just :email. You can configure it to use [:username, :subdomain], so for
+  # authenticating a user, both parameters are required. Remember that those
+  # parameters are used only when authenticating and not when retrieving from
+  # session. If you need permissions, you should implement that in a before filter.
+  # You can also supply a hash where the value is a boolean determining whether
+  # or not authentication should be aborted when the value is not present.
+  # config.authentication_keys = [:email]
+
+  # Configure parameters from the request object used for authentication. Each entry
+  # given should be a request method and it will automatically be passed to the
+  # find_for_authentication method and considered in your model lookup. For instance,
+  # if you set :request_keys to [:subdomain], :subdomain will be used on authentication.
+  # The same considerations mentioned for authentication_keys also apply to request_keys.
+  # config.request_keys = []
+
+  # Configure which authentication keys should be case-insensitive.
+  # These keys will be downcased upon creating or modifying a user and when used
+  # to authenticate or find a user. Default is :email.
+  config.case_insensitive_keys = [:email]
+
+  # Configure which authentication keys should have whitespace stripped.
+  # These keys will have whitespace before and after removed upon creating or
+  # modifying a user and when used to authenticate or find a user. Default is :email.
+  config.strip_whitespace_keys = [:email]
+
+  # Tell if authentication through request.params is enabled. True by default.
+  # It can be set to an array that will enable params authentication only for the
+  # given strategies, for example, `config.params_authenticatable = [:database]` will
+  # enable it only for database (email + password) authentication.
+  # config.params_authenticatable = true
+
+  # Tell if authentication through HTTP Auth is enabled. False by default.
+  # It can be set to an array that will enable http authentication only for the
+  # given strategies, for example, `config.http_authenticatable = [:database]` will
+  # enable it only for database authentication. The supported strategies are:
+  # :database      = Support basic authentication with authentication key + password
+  # config.http_authenticatable = false
+
+  # If 401 status code should be returned for AJAX requests. True by default.
+  # config.http_authenticatable_on_xhr = true
+
+  # The realm used in Http Basic Authentication. 'Application' by default.
+  # config.http_authentication_realm = 'Application'
+
+  # It will change confirmation, password recovery and other workflows
+  # to behave the same regardless if the e-mail provided was right or wrong.
+  # Does not affect registerable.
+  # config.paranoid = true
+
+  # By default Devise will store the user in session. You can skip storage for
+  # particular strategies by setting this option.
+  # Notice that if you are skipping storage for all authentication paths, you
+  # may want to disable generating routes to Devise's sessions controller by
+  # passing skip: :sessions to `devise_for` in your config/routes.rb
+  config.skip_session_storage = [:http_auth]
+
+  # By default, Devise cleans up the CSRF token on authentication to
+  # avoid CSRF token fixation attacks. This means that, when using AJAX
+  # requests for sign in and sign up, you need to get a new CSRF token
+  # from the server. You can disable this option at your own risk.
+  # config.clean_up_csrf_token_on_authentication = true
+
+  # When false, Devise will not attempt to reload routes on eager load.
+  # This can reduce the time taken to boot the app but if your application
+  # requires the Devise mappings to be loaded during boot time the application
+  # won't boot properly.
+  # config.reload_routes = true
+
+  # ==> Configuration for :database_authenticatable
+  # For bcrypt, this is the cost for hashing the password and defaults to 11. If
+  # using other algorithms, it sets how many times you want the password to be hashed.
+  #
+  # Limiting the stretches to just one in testing will increase the performance of
+  # your test suite dramatically. However, it is STRONGLY RECOMMENDED to not use
+  # a value less than 10 in other environments. Note that, for bcrypt (the default
+  # algorithm), the cost increases exponentially with the number of stretches (e.g.
+  # a value of 20 is already extremely slow: approx. 60 seconds for 1 calculation).
+  config.stretches = Rails.env.test? ? 1 : 11
+
+  # Set up a pepper to generate the hashed password.
+  # config.pepper = '62bb37208fc8ac4e8821dda6bf9a7abfc82fdbefc9c00eda3304d0d54572f2e6c0ca2e8ce4376fc3b66499d17a269bfd396e40fbb400a270001d8fdc6f996887'
+
+  # Send a notification to the original email when the user's email is changed.
+  # config.send_email_changed_notification = false
+
+  # Send a notification email when the user's password is changed.
+  # config.send_password_change_notification = false
+
+  # ==> Configuration for :confirmable
+  # A period that the user is allowed to access the website even without
+  # confirming their account. For instance, if set to 2.days, the user will be
+  # able to access the website for two days without confirming their account,
+  # access will be blocked just in the third day. Default is 0.days, meaning
+  # the user cannot access the website without confirming their account.
+  # config.allow_unconfirmed_access_for = 2.days
+
+  # A period that the user is allowed to confirm their account before their
+  # token becomes invalid. For example, if set to 3.days, the user can confirm
+  # their account within 3 days after the mail was sent, but on the fourth day
+  # their account can't be confirmed with the token any more.
+  # Default is nil, meaning there is no restriction on how long a user can take
+  # before confirming their account.
+  # config.confirm_within = 3.days
+
+  # If true, requires any email changes to be confirmed (exactly the same way as
+  # initial account confirmation) to be applied. Requires additional unconfirmed_email
+  # db field (see migrations). Until confirmed, new email is stored in
+  # unconfirmed_email column, and copied to email column on successful confirmation.
+  config.reconfirmable = true
+
+  # Defines which key will be used when confirming an account
+  # config.confirmation_keys = [:email]
+
+  # ==> Configuration for :rememberable
+  # The time the user will be remembered without asking for credentials again.
+  # config.remember_for = 2.weeks
+
+  # Invalidates all the remember me tokens when the user signs out.
+  config.expire_all_remember_me_on_sign_out = true
+
+  # If true, extends the user's remember period when remembered via cookie.
+  # config.extend_remember_period = false
+
+  # Options to be passed to the created cookie. For instance, you can set
+  # secure: true in order to force SSL only cookies.
+  # config.rememberable_options = {}
+
+  # ==> Configuration for :validatable
+  # Range for password length.
+  config.password_length = 6..128
+
+  # Email regex used to validate email formats. It simply asserts that
+  # one (and only one) @ exists in the given string. This is mainly
+  # to give user feedback and not to assert the e-mail validity.
+  config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
+
+  # ==> Configuration for :timeoutable
+  # The time you want to timeout the user session without activity. After this
+  # time the user will be asked for credentials again. Default is 30 minutes.
+  # config.timeout_in = 30.minutes
+
+  # ==> Configuration for :lockable
+  # Defines which strategy will be used to lock an account.
+  # :failed_attempts = Locks an account after a number of failed attempts to sign in.
+  # :none            = No lock strategy. You should handle locking by yourself.
+  # config.lock_strategy = :failed_attempts
+
+  # Defines which key will be used when locking and unlocking an account
+  # config.unlock_keys = [:email]
+
+  # Defines which strategy will be used to unlock an account.
+  # :email = Sends an unlock link to the user email
+  # :time  = Re-enables login after a certain amount of time (see :unlock_in below)
+  # :both  = Enables both strategies
+  # :none  = No unlock strategy. You should handle unlocking by yourself.
+  # config.unlock_strategy = :both
+
+  # Number of authentication tries before locking an account if lock_strategy
+  # is failed attempts.
+  # config.maximum_attempts = 20
+
+  # Time interval to unlock the account if :time is enabled as unlock_strategy.
+  # config.unlock_in = 1.hour
+
+  # Warn on the last attempt before the account is locked.
+  # config.last_attempt_warning = true
+
+  # ==> Configuration for :recoverable
+  #
+  # Defines which key will be used when recovering the password for an account
+  # config.reset_password_keys = [:email]
+
+  # Time interval you can reset your password with a reset password key.
+  # Don't put a too small interval or your users won't have the time to
+  # change their passwords.
+  config.reset_password_within = 6.hours
+
+  # When set to false, does not sign a user in automatically after their password is
+  # reset. Defaults to true, so a user is signed in automatically after a reset.
+  # config.sign_in_after_reset_password = true
+
+  # ==> Configuration for :encryptable
+  # Allow you to use another hashing or encryption algorithm besides bcrypt (default).
+  # You can use :sha1, :sha512 or algorithms from others authentication tools as
+  # :clearance_sha1, :authlogic_sha512 (then you should set stretches above to 20
+  # for default behavior) and :restful_authentication_sha1 (then you should set
+  # stretches to 10, and copy REST_AUTH_SITE_KEY to pepper).
+  #
+  # Require the `devise-encryptable` gem when using anything other than bcrypt
+  # config.encryptor = :sha512
+
+  # ==> Scopes configuration
+  # Turn scoped views on. Before rendering "sessions/new", it will first check for
+  # "users/sessions/new". It's turned off by default because it's slower if you
+  # are using only default views.
+  # config.scoped_views = false
+
+  # Configure the default scope given to Warden. By default it's the first
+  # devise role declared in your routes (usually :user).
+  # config.default_scope = :user
+
+  # Set this configuration to false if you want /users/sign_out to sign out
+  # only the current scope. By default, Devise signs out all scopes.
+  # config.sign_out_all_scopes = true
+
+  # ==> Navigation configuration
+  # Lists the formats that should be treated as navigational. Formats like
+  # :html, should redirect to the sign in page when the user does not have
+  # access, but formats like :xml or :json, should return 401.
+  #
+  # If you have any extra navigational formats, like :iphone or :mobile, you
+  # should add them to the navigational formats lists.
+  #
+  # The "*/*" below is required to match Internet Explorer requests.
+  # config.navigational_formats = ['*/*', :html]
+
+  # The default HTTP method used to sign out a resource. Default is :delete.
+  config.sign_out_via = :delete
+
+  # ==> OmniAuth
+  # Add a new OmniAuth provider. Check the wiki for more information on setting
+  # up on your models and hooks.
+  # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
+
+  # ==> Warden configuration
+  # If you want to use other strategies, that are not supported by Devise, or
+  # change the failure app, you can configure them inside the config.warden block.
+  #
+  # config.warden do |manager|
+  #   manager.intercept_401 = false
+  #   manager.default_strategies(scope: :user).unshift :some_external_strategy
+  # end
+
+  # ==> Mountable engine configurations
+  # When using Devise inside an engine, let's call it `MyEngine`, and this engine
+  # is mountable, there are some extra configurations to be taken into account.
+  # The following options are available, assuming the engine is mounted as:
+  #
+  #     mount MyEngine, at: '/my_engine'
+  #
+  # The router that invoked `devise_for`, in the example above, would be:
+  # config.router_name = :my_engine
+  #
+  # When using OmniAuth, Devise cannot automatically set OmniAuth path,
+  # so you need to do it manually. For the users scope, it would be:
+  # config.omniauth_path_prefix = '/my_engine/users/auth'
+end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -3,13 +3,13 @@
 # Use this hook to configure devise mailer, warden hooks and so forth.
 # Many of these configuration options can be set straight in your model.
 Devise.setup do |config|
+  config.omniauth :twitter, ENV["TWITTER_API_KEY"], ENV["TWITTER_API_SECRET"]
   # The secret key used by Devise. Devise uses this key to generate
   # random tokens. Changing this key will render invalid all existing
   # confirmation, reset password and unlock tokens in the database.
   # Devise will use the `secret_key_base` as its `secret_key`
   # by default. You can change it below and use your own secret key.
   # config.secret_key = '330bf1990cae612411a8a585e505bef9216111f8f91be0dccbe774a560cbb22e55de3396004ffd15e180021f6f2dc3b0109cb62b1c0dd2388c78eec22c241514'
-  
   # ==> Controller configuration
   # Configure the parent class to the devise controllers.
   # config.parent_controller = 'DeviseController'

--- a/config/initializers/rakuten_web_service.rb
+++ b/config/initializers/rakuten_web_service.rb
@@ -1,0 +1,3 @@
+RakutenWebService. configuration do |c|
+  c.application_id = ENV['RAKUTEN_APPLICATION_ID']
+end

--- a/config/initializers/rakuten_web_service.rb
+++ b/config/initializers/rakuten_web_service.rb
@@ -1,3 +1,3 @@
-RakutenWebService. configuration do |c|
-  c.application_id = ENV['RAKUTEN_APPLICATION_ID']
+RakutenWebService.configure do |c|
+  c.application_id = ENV["RAKUTEN_APPLICATION_ID"]
 end

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -1,0 +1,64 @@
+# Additional translations at https://github.com/plataformatec/devise/wiki/I18n
+
+en:
+  devise:
+    confirmations:
+      confirmed: "Your email address has been successfully confirmed."
+      send_instructions: "You will receive an email with instructions for how to confirm your email address in a few minutes."
+      send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes."
+    failure:
+      already_authenticated: "You are already signed in."
+      inactive: "Your account is not activated yet."
+      invalid: "Invalid %{authentication_keys} or password."
+      locked: "Your account is locked."
+      last_attempt: "You have one more attempt before your account is locked."
+      not_found_in_database: "Invalid %{authentication_keys} or password."
+      timeout: "Your session expired. Please sign in again to continue."
+      unauthenticated: "You need to sign in or sign up before continuing."
+      unconfirmed: "You have to confirm your email address before continuing."
+    mailer:
+      confirmation_instructions:
+        subject: "Confirmation instructions"
+      reset_password_instructions:
+        subject: "Reset password instructions"
+      unlock_instructions:
+        subject: "Unlock instructions"
+      email_changed:
+        subject: "Email Changed"
+      password_change:
+        subject: "Password Changed"
+    omniauth_callbacks:
+      failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
+      success: "Successfully authenticated from %{kind} account."
+    passwords:
+      no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
+      send_instructions: "You will receive an email with instructions on how to reset your password in a few minutes."
+      send_paranoid_instructions: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
+      updated: "Your password has been changed successfully. You are now signed in."
+      updated_not_active: "Your password has been changed successfully."
+    registrations:
+      destroyed: "Bye! Your account has been successfully cancelled. We hope to see you again soon."
+      signed_up: "Welcome! You have signed up successfully."
+      signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."
+      signed_up_but_locked: "You have signed up successfully. However, we could not sign you in because your account is locked."
+      signed_up_but_unconfirmed: "A message with a confirmation link has been sent to your email address. Please follow the link to activate your account."
+      update_needs_confirmation: "You updated your account successfully, but we need to verify your new email address. Please check your email and follow the confirm link to confirm your new email address."
+      updated: "Your account has been updated successfully."
+    sessions:
+      signed_in: "Signed in successfully."
+      signed_out: "Signed out successfully."
+      already_signed_out: "Signed out successfully."
+    unlocks:
+      send_instructions: "You will receive an email with instructions for how to unlock your account in a few minutes."
+      send_paranoid_instructions: "If your account exists, you will receive an email with instructions for how to unlock it in a few minutes."
+      unlocked: "Your account has been unlocked successfully. Please sign in to continue."
+  errors:
+    messages:
+      already_confirmed: "was already confirmed, please try signing in"
+      confirmation_period_expired: "needs to be confirmed within %{period}, please request a new one"
+      expired: "has expired, please request a new one"
+      not_found: "not found"
+      not_locked: "was not locked"
+      not_saved:
+        one: "1 error prohibited this %{resource} from being saved:"
+        other: "%{count} errors prohibited this %{resource} from being saved:"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,204 @@
+ja:
+  activerecord:
+    errors:
+      messages:
+        record_invalid: "バリデーションに失敗しました: %{errors}"
+        restrict_dependent_destroy:
+          has_one: "%{record}が存在しているので削除できません"
+          has_many: "%{record}が存在しているので削除できません"
+  date:
+    abbr_day_names:
+    - 日
+    - 月
+    - 火
+    - 水
+    - 木
+    - 金
+    - 土
+    abbr_month_names:
+    -
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    day_names:
+    - 日曜日
+    - 月曜日
+    - 火曜日
+    - 水曜日
+    - 木曜日
+    - 金曜日
+    - 土曜日
+    formats:
+      default: "%Y/%m/%d"
+      long: "%Y年%m月%d日(%a)"
+      short: "%m/%d"
+    month_names:
+    -
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    order:
+    - :year
+    - :month
+    - :day
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: 約1時間
+        other: 約%{count}時間
+      about_x_months:
+        one: 約1ヶ月
+        other: 約%{count}ヶ月
+      about_x_years:
+        one: 約1年
+        other: 約%{count}年
+      almost_x_years:
+        one: 1年弱
+        other: "%{count}年弱"
+      half_a_minute: 30秒前後
+      less_than_x_minutes:
+        one: 1分以内
+        other: "%{count}分未満"
+      less_than_x_seconds:
+        one: 1秒以内
+        other: "%{count}秒未満"
+      over_x_years:
+        one: 1年以上
+        other: "%{count}年以上"
+      x_days:
+        one: 1日
+        other: "%{count}日"
+      x_minutes:
+        one: 1分
+        other: "%{count}分"
+      x_months:
+        one: 1ヶ月
+        other: "%{count}ヶ月"
+      x_years:
+        one: 1年
+        other: "%{count}年"
+      x_seconds:
+        one: 1秒
+        other: "%{count}秒"
+    prompts:
+      day: 日
+      hour: 時
+      minute: 分
+      month: 月
+      second: 秒
+      year: 年
+  errors:
+    format: "%{attribute}%{message}"
+    messages:
+      accepted: を受諾してください
+      blank: を入力してください
+      present: は入力しないでください
+      confirmation: と%{attribute}の入力が一致しません
+      empty: を入力してください
+      equal_to: は%{count}にしてください
+      even: は偶数にしてください
+      exclusion: は予約されています
+      greater_than: は%{count}より大きい値にしてください
+      greater_than_or_equal_to: は%{count}以上の値にしてください
+      inclusion: は一覧にありません
+      invalid: は不正な値です
+      less_than: は%{count}より小さい値にしてください
+      less_than_or_equal_to: は%{count}以下の値にしてください
+      model_invalid: "バリデーションに失敗しました: %{errors}"
+      not_a_number: は数値で入力してください
+      not_an_integer: は整数で入力してください
+      odd: は奇数にしてください
+      required: を入力してください
+      taken: はすでに存在します
+      too_long: は%{count}文字以内で入力してください
+      too_short: は%{count}文字以上で入力してください
+      wrong_length: は%{count}文字で入力してください
+      other_than: は%{count}以外の値にしてください
+    template:
+      body: 次の項目を確認してください
+      header:
+        one: "%{model}にエラーが発生しました"
+        other: "%{model}に%{count}個のエラーが発生しました"
+  helpers:
+    select:
+      prompt: 選択してください
+    submit:
+      create: 登録する
+      submit: 保存する
+      update: 更新する
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%n%u"
+        precision: 0
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: 円
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: 十億
+          million: 百万
+          quadrillion: 千兆
+          thousand: 千
+          trillion: 兆
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n%u"
+        units:
+          byte: バイト
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: 、
+      two_words_connector: 、
+      words_connector: 、
+  time:
+    am: 午前
+    formats:
+      default: "%Y/%m/%d %H:%M:%S"
+      long: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
+      short: "%y/%m/%d %H:%M"
+    pm: 午後

--- a/config/locales/models/user.yml
+++ b/config/locales/models/user.yml
@@ -1,0 +1,9 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        username: '名前'
+        email: 'Email'
+  users:
+  remember_me: 'ログインを記憶する'
+  back: '戻る'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,5 @@
 Rails.application.routes.draw do
+  root to: 'top#index'
+
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,5 @@
 Rails.application.routes.draw do
-  get 'post/index'
-
-  get 'post/show'
-
-  get 'post/edit'
+  resources :posts, only: [:index, :show, :edit, :update, :destroy]
 
   devise_for :users, controllers: { :omniauth_callbacks => "omniauth_callbacks" }
   root to: 'top#index'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,10 @@
 Rails.application.routes.draw do
+  get 'post/index'
+
+  get 'post/show'
+
+  get 'post/edit'
+
   devise_for :users, controllers: { :omniauth_callbacks => "omniauth_callbacks" }
   root to: 'top#index'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  devise_for :users, controllers: { :omniauth_callbacks => "omniauth_callbacks" }
   root to: 'top#index'
 
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html

--- a/db/migrate/20180517031012_devise_create_users.rb
+++ b/db/migrate/20180517031012_devise_create_users.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+class DeviseCreateUsers < ActiveRecord::Migration[5.1]
+  def change
+    create_table :users do |t|
+      ## Database authenticatable
+      t.string :email,              null: false, default: ""
+      t.string :encrypted_password, null: false, default: ""
+
+      ## Recoverable
+      t.string   :reset_password_token
+      t.datetime :reset_password_sent_at
+
+      ## Rememberable
+      t.datetime :remember_created_at
+
+      ## Trackable
+      t.integer  :sign_in_count, default: 0, null: false
+      t.datetime :current_sign_in_at
+      t.datetime :last_sign_in_at
+      t.string   :current_sign_in_ip
+      t.string   :last_sign_in_ip
+
+      # Confirmable
+      t.string   :confirmation_token
+      t.datetime :confirmed_at
+      t.datetime :confirmation_sent_at
+      t.string   :unconfirmed_email # Only if using reconfirmable
+
+      # Lockable
+      t.integer  :failed_attempts, default: 0, null: false # Only if lock strategy is :failed_attempts
+      t.string   :unlock_token # Only if unlock strategy is :email or :both
+      t.datetime :locked_at
+
+
+      t.timestamps null: false
+    end
+
+    add_index :users, :email,                unique: true
+    add_index :users, :reset_password_token, unique: true
+    add_index :users, :confirmation_token,   unique: true
+    add_index :users, :unlock_token,         unique: true
+  end
+end

--- a/db/migrate/20180517031336_add_columns_to_users.rb
+++ b/db/migrate/20180517031336_add_columns_to_users.rb
@@ -1,0 +1,7 @@
+class AddColumnsToUsers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :provider, :string
+    add_column :users, :uid, :string
+    add_column :users, :name, :string
+  end
+end

--- a/db/migrate/20180517113737_create_posts.rb
+++ b/db/migrate/20180517113737_create_posts.rb
@@ -1,0 +1,13 @@
+class CreatePosts < ActiveRecord::Migration[5.1]
+  def change
+    create_table :posts do |t|
+      t.string :name
+      t.string :campany
+      t.string :city
+      t.string :sake_name
+      t.string :kana_name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20180520051210_rename_campany_to_posts.rb
+++ b/db/migrate/20180520051210_rename_campany_to_posts.rb
@@ -1,0 +1,5 @@
+class RenameCampanyToPosts < ActiveRecord::Migration[5.1]
+  def change
+    rename_column :posts, :campany, :company
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180517031336) do
+ActiveRecord::Schema.define(version: 20180520051210) do
+
+  create_table "posts", force: :cascade do |t|
+    t.string "name"
+    t.string "company"
+    t.string "city"
+    t.string "sake_name"
+    t.string "kana_name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,44 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 20180517031336) do
+
+  create_table "users", force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.integer "sign_in_count", default: 0, null: false
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.string "current_sign_in_ip"
+    t.string "last_sign_in_ip"
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string "unconfirmed_email"
+    t.integer "failed_attempts", default: 0, null: false
+    t.string "unlock_token"
+    t.datetime "locked_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "provider"
+    t.string "uid"
+    t.string "name"
+    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true
+  end
+
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,17 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+# ActiveSupport::JSONを使ってhoge.jsonをデコードしてrubyオブジェクトに変換。変数jsonに展開
+json = ActiveSupport::JSON.decode(File.read('sake.json'))
+
+# 変数jsonに入った配列状態のjsonデータを一つ一つ取り出して、モデル.createを使ってdbに投入
+json.each do |data|
+  data['city_r'].each do |city_r|
+    city_r['details'].each do |detail|
+      Post.create(
+        name: data['name_n'],
+        company: city_r['company'],
+        city: city_r['city'],
+        sake_name: detail['name'],
+        kana_name: detail['kana_name']
+        )
+    end
+  end
+end

--- a/sake.json
+++ b/sake.json
@@ -1,0 +1,3168 @@
+[
+{"name_n": "北海道", "city_r":[
+  {"company":"田中酒造","city":"小樽市", "details":[
+    {"name":"小樽の貴醸酒","kana_name":"おたるのきじょうしゅ"},
+    {"name":"亀甲蔵大吟醸","kana_name":"きっこうぐらだいぎんじょう"},
+    {"name":"寳川","kana_name":"たからがわ"},
+    {"name":"七年貯熟古酒","kana_name":"しちねんちょじゅくこしゅ"}]},
+  {"company":"男山","city":"旭川市", "details":[
+    {"name":"男山","kana_name":"おとこやま"}]},
+  {"company":"高砂酒造","city":"旭川市", "details":[
+    {"name":"国士無双","kana_name":"こくしむそう"}]},
+  {"company":"合同酒精旭川工場","city":"旭川市", "details":[
+    {"name":"大雪乃蔵","kana_name":"たいせつのくら"},
+    {"name":"北の誉","kana_name":"きたのほまれ"}]},
+  {"company":"小林酒造","city":"夕張郡栗山町", "details":[
+    {"name":"北の錦","kana_name":"きたのにしき"},
+    {"name":"北のろまん","kana_name":"きたのろまん"},
+    {"name":"吟風","kana_name":"ぎんぷう"},
+    {"name": "くらまち", "kana_name": "くらまち"},
+    {"name":"北斗随想","kana_name":"ほくとずいそう"},
+    {"name":"北海二七八","kana_name":"ほっかいにーななはち"},
+    {"name":"まる田","kana_name":"まるた"},
+    {"name":"雪晒","kana_name":"ゆきさらし"}]},
+  {"company":"株式会社江別商会","city":"江別市", "details":[
+    {"name":"江別の詩","kana_name":"えべつのうた"},
+    {"name": "ななかまど", "kana_name":"ななかまど"}]},
+  {"company":"金滴酒造","city":"樺戸郡新十津川町", "details":[
+    {"name":"おのらの酒","kana_name":"おのらのさけ"},
+    {"name":"北の微笑","kana_name":"きたのほほえみ"},
+    {"name":"きらら397","kana_name":"きららさんきゅうなな"},
+    {"name":"金滴","kana_name":"きんてき"},
+    {"name":"雫の浪漫","kana_name":"しずくのろまん"},
+    {"name":"瑞鳳","kana_name":"ずいほう"},
+    {"name":"杜氏の夢呑","kana_name":"とうじのゆめのみ"},
+    {"name":"徳富","kana_name":"とっぷ"},
+    {"name":"冬凪","kana_name":"ふゆなぎ"},
+    {"name":"微笑一献","kana_name":"ほほえみいっこん"},
+    {"name":"雪だるま","kana_name":"ゆきだるま"},
+    {"name":"夢きらら","kana_name":"ゆめきらら"},
+    {"name":"夢滴","kana_name":"ゆめしずく"}]},
+  {"company":"碓氷勝三郎商店","city":"根室市", "details":[
+    {"name":"北の勝","kana_name":"きたのかつ"}]},
+  {"company":"國稀酒造","city":"増毛町", "details":[
+    {"name":"國稀","kana_name":"くにまれ"},
+    {"name":"北海鬼ころし","kana_name":"ほっかいおにころし"},
+    {"name":"雪のかおり","kana_name":"ゆきのかおり"}]},
+  {"company":"日本清酒","city":"札幌市", "details":[
+    {"name":"千歳鶴","kana_name":"ちとせつる"}]},
+  {"company":"二世古酒造","city":"倶知安町", "details":[
+    {"name":"二世古","kana_name":"にせこ"}]},
+  {"company":"福司酒造","city":"釧路市", "details":[
+    {"name":"福司","kana_name":"ふくつかさ"},
+    {"name":"海底力","kana_name":"そこヂカラ"},
+    {"name":"花華","kana_name":"はなはな"},
+    {"name":"北輝光","kana_name":"ほっきこう"},
+    {"name":"海霧","kana_name":"うみぎり"},
+    {"name":"霧氷","kana_name":"むひょう"},
+    {"name":"霧小町","kana_name":"きりこまち"},
+    {"name":"千羽鶴","kana_name":"せんばつる"},
+    {"name":"しつげん","kana_name":"しつげん"},
+    {"name":"鮭ひれ酒","kana_name":"さけひれさけ"},
+    {"name":"ポンエペレ","kana_name":"ポンエペレ"},
+    {"name":"拾八","kana_name":"じゅうはち"},
+    {"name":"“く”しろうさぎ","kana_name":"くしろうさぎ"},
+    {"name":"鶴","kana_name":"つる"}]},
+  {"company":"山田酒造","city":"北見市", "details":[
+    {"name":"摩周","kana_name":"ましゅう"}]}
+]},
+{"name_n":"青森県", "city_r":[
+  {"company":"六花酒造","city":"弘前市", "details":[
+    {"name":"じょっぱり","kana_name":"じょっぱり"}]},
+  {"company":"三浦酒造店","city":"弘前市", "details":[
+    {"name":"豊盃","kana_name":"ほうはい"},
+    {"name":"ん","kana_name":"ん"}]},
+  {"company":"斎藤酒造","city":"弘前市", "details":[
+    {"name":"霊峰","kana_name":"れいほう"},
+    {"name":"雪の白神","kana_name":"雪の白神"},
+    {"name":"津軽の祭り","kana_name":"つがるのまつり"},
+    {"name":"北のまほろば","kana_name":"きたのまほろば"},
+    {"name":"六根","kana_name":"ろっこん"}]},
+  {"company":"吉井酒造","city":"弘前市", "details":[
+    {"name":"吉野桜","kana_name":"よしのさくら"}]},
+  {"company":"寿酒造","city":"弘前市", "details":[
+    {"name":"寿","kana_name":"ことぶき"}]},
+  {"company":"丸竹酒造","city":"弘前市", "details":[
+    {"name":"白神のロマン","kana_name":"しらかみのろまん"}]},
+  {"company":"白神酒造","city":"弘前市", "details":[
+    {"name":"白神","kana_name":"しらかみ"}]},
+  {"company":"八戸酒造","city":"八戸市", "details":[
+    {"name":"福牡丹","kana_name":"ふくぼたん"},
+    {"name":"八仙","kana_name":"はっせん"},
+    {"name":"田心","kana_name":"でんしん"},
+    {"name":"男山","kana_name":"おとこやま"}]},
+  {"company":"八戸酒類八鶴工場","city":"八戸市", "details":[
+    {"name":"八鶴","kana_name":"はちつる"},
+    {"name":"海の樹ロマン","kana_name":"うみのきろまん"}]},
+  {"company":"八戸酒類みなと工場","city":"八戸市", "details":[
+    {"name":"蔵の物語","kana_name":"くらのものがたり"}]},
+  {"company":"八戸酒類花開工場","city":"八戸市", "details":[
+    {"name":"俵づみ","kana_name":"たわらづみ"}]},
+  {"company":"八戸酒類五戸工場","city":"三戸郡五戸町", "details":[
+    {"name":"如空","kana_name":"じょくう"},
+    {"name":"秋あがり","kana_name":"あきあがり"}]},
+  {"company":"西田酒造店","city":"青森市", "details":[
+    {"name":"喜久泉","kana_name":"きくいずみ"},
+    {"name":"田酒","kana_name":"でんしゅ"}]},
+  {"company":"盛庄酒造店","city":"上北郡七戸町", "details":[
+    {"name":"駒泉","kana_name":"こまいずみ"},
+    {"name":"作田","kana_name":"さくた"}]},
+  {"company":"十和田正宗盛喜","city":"上北郡七戸町", "details":[
+    {"name":"十和田正宗","kana_name":"とわだまさむね"}]},
+  {"company":"桃川","city":"上北郡おいらせ町", "details":[
+    {"name":"桃川","kana_name":"ももかわ"}]},
+  {"company":"関乃井酒造","city":"むつ市", "details":[
+    {"name":"関乃井","kana_name":"せきのい"}]},
+  {"company":"鳩正宗","city":"十和田市", "details":[
+    {"name":"鳩正宗","kana_name":"はとまさむね"},
+    {"name":"八甲田おろし","kana_name":"はっこうだおろし"}]},
+  {"company":"中村亀吉","city":"黒石市", "details":[
+    {"name":"津軽娘","kana_name":"つがるむすめ"},
+    {"name":"亀吉","kana_name":"かめきち"},
+    {"name":"玉垂","kana_name":"たまだれ"},
+    {"name":"ねぶた囃子","kana_name":"ねぶたばやし"}]},
+  {"company":"尾崎酒造","city":"西津軽郡鰺ヶ沢町", "details":[
+    {"name":"安東水軍","kana_name":"あんどうすいぐん"},
+    {"name":"神の座","kana_name":"かみのざ"},
+    {"name":"白神のしずく","kana_name":"しらかみのしずく"}]},
+  {"company":"長内酒造店","city":"つがる市", "details":[
+    {"name":"明ケ烏","kana_name":"あけがらす"}]}
+]},
+{"name_n":"岩手県","city_r":[
+  {"company":"吾妻嶺酒造","city":"紫波郡紫波町", "details":[
+    {"name":"吾妻嶺","kana_name":"あづまみね"},
+    {"name":"悠楽","kana_name":"ゆうらく"},
+    {"name":"鸛","kana_name":"こうのとり"}]},
+  {"company":"月の輪酒造店","city":"紫波郡紫波町", "details":[
+    {"name":"月の輪","kana_name":"つきのわ"},
+    {"name":"宵の月","kana_name":"よいのつき"},
+    {"name":"もちっ娘","kana_name":"もちっこ"}]},
+  {"company":"広田酒造店","city":"紫波郡紫波町", "details":[
+    {"name":"広喜","kana_name":"ひろき"}]},
+  {"company":"高橋酒造店","city":"紫波郡紫波町", "details":[
+    {"name":"堀の井","kana_name":"ほりのい"}]},
+  {"company":"あさ開","city":"盛岡市", "details":[
+    {"name":"あさ開","kana_name":"あさびらき"},
+    {"name":"旭扇","kana_name":"きょくせん"},
+    {"name":"夢灯り","kana_name":"ゆめあかり"}]},
+  {"company":"桜顔酒造","city":"盛岡市", "details":[
+    {"name":"桜顔","kana_name":"さくらがお"},
+    {"name":"北国の恋人","kana_name":"きたぐにのこいびと"},
+    {"name":"北の寒桜","kana_name":"きたのかんざくら"}]},
+  {"company":"菊の司酒造","city":"盛岡市", "details":[
+    {"name":"菊の司","kana_name":"きくのつかさ"},
+    {"name":"七福神","kana_name":"しちふくじん"}]},
+  {"company":"川村酒造店","city":"花巻市", "details":[
+    {"name":"南部関","kana_name":"なんぶぜき"},
+    {"name":"酉与右衛門","kana_name":"よえもん"}]},
+  {"company":"磐乃井酒造","city":"一関市", "details":[
+    {"name":"磐乃井","kana_name":"いわのい"}]},
+  {"company":"世嬉の一酒造","city":"一関市", "details":[
+    {"name":"世嬉の一","kana_name":"せきのいち"}]},
+  {"company":"両磐酒造","city":"一関市", "details":[
+    {"name":"関山","kana_name":"かんざん"}]},
+  {"company":"喜久盛酒造","city":"北上市", "details":[
+    {"name":"喜久盛","kana_name":"きくざかり"},
+    {"name":"鬼剣舞","kana_name":"おにけんばい"},
+    {"name":"鹿踊り","kana_name":"ししおどり"},
+    {"name":"北上夜曲","kana_name":"きたかみやきょく"},
+    {"name":"電気菩薩","kana_name":"でんきぼさつ"}]},
+  {"company":"南部美人","city":"二戸市", "details":[
+    {"name":"南部美人","kana_name":"なんぶびじん"}]},
+  {"company":"福来 ","city":"久慈市", "details":[
+    {"name":"福来","kana_name":"ふくらい"}]},
+  {"company":"わしの尾","city":"八幡平市", "details":[
+    {"name":"鷲の尾","kana_name":"わしのお"},
+    {"name":"雋","kana_name":"せん"}]},
+  {"company":"泉金酒造","city":"下閉伊郡岩泉町", "details":[
+    {"name":"龍泉 八重桜","kana_name":"りゅうせん やえざくら"}]},
+  {"company":"菱屋酒造","city":"宮古市", "details":[
+    {"name":"千両 男山","kana_name":"せんりょう おとこやま"}]},
+  {"company":"浜千鳥","city":"釜石市", "details":[
+    {"name":"浜千鳥","kana_name":"はまちどり"}]},
+  {"company":"赤武酒造","city":"上閉伊郡大槌町", "details":[
+    {"name":"浜娘","kana_name":"はまむすめ"}]},
+  {"company":"酔仙酒造","city":"陸前高田市", "details":[
+    {"name":"酔仙","kana_name":"すいせん"},
+    {"name":"雪っこ","kana_name":"ゆきっこ"}]},
+  {"company":"天瓢","city":"奥州市", "details":[
+    {"name":"天瓢","kana_name":"てんぴょう"},
+    {"name":"蒼天","kana_name":"そうてん"},
+    {"name":"阿弖流爲","kana_name":"あてるい"}]},
+  {"company":"岩手銘醸","city":"奥州市", "details":[
+    {"name":"岩手誉","kana_name":"いわてほまれ"},
+    {"name":"草庵諸白","kana_name":""}]}
+]},
+{"name_n":"宮城県","city_r":[
+  {"company":"新澤醸造店","city":"大崎市", "details":[
+    {"name":"愛宕の松","kana_name":"あたごのまつ"},
+    {"name":"伯楽星","kana_name":"はくらくせい"}]},
+  {"company":"一ノ蔵","city":"大崎市", "details":[
+    {"name":"一ノ蔵","kana_name":"いちのくら"}]},
+  {"company":"寒梅酒造","city":"大崎市", "details":[
+    {"name":"宮寒梅","kana_name":"みやかんばい"}]},
+  {"company":"森民酒造店","city":"大崎市", "details":[
+    {"name":"森泉","kana_name":"もりいずみ"}]},
+  {"company":"佐浦","city":"塩竈市", "details":[
+    {"name":"浦霞","kana_name":"うらかすみ"}]},
+  {"company":"阿部勘酒造店","city":"塩竈市", "details":[
+    {"name":"阿部勘","kana_name":"あべかん"},
+    {"name":"於茂多加 男山","kana_name":"おもたか"}]},
+  {"company":"麹屋酒造店","city":"塩竈市", "details":[
+    {"name":"福釜","kana_name":"ふくがま"}]},
+  {"company":"千田酒造","city":"栗原市", "details":[
+    {"name":"栗駒山","kana_name":"くりこまやま"},
+    {"name":"奥鶴","kana_name":"おくつる"}]},
+  {"company":"金の井酒造","city":"栗原市", "details":[
+    {"name":"綿屋","kana_name":"わたや"},
+    {"name":"金の井","kana_name":"かねのい"}]},
+  {"company":"萩野酒造","city":"栗原市", "details":[
+    {"name":"萩の鶴","kana_name":"はぎのつる"}]},
+  {"company":"はさまや酒造店","city":"栗原市", "details":[
+    {"name":"桂泉","kana_name":"けいせん"}]},
+  {"company":"仙台伊澤家 勝山酒造","city":"仙台市", "details":[
+    {"name":"勝山","kana_name":"かつやま"},
+    {"name":"戦勝政宗","kana_name":"せんしょうまさむね"}]},
+  {"company":"森民總本家","city":"仙台市", "details":[
+    {"name":"森乃菊川","kana_name":"もりのきくかわ"}]},
+  {"company":"石川酒造店","city":"石巻市", "details":[
+    {"name":"北上川","kana_name":"きたかみがわ"}]},
+  {"company":"平孝酒造","city":"石巻市", "details":[
+    {"name":"新関","kana_name":"しんぜき"},
+    {"name":"日高見","kana_name":"ひたかみ"}]},
+  {"company":"墨廼江酒造","city":"石巻市", "details":[
+    {"name":"墨廼江","kana_name":"すみのえ"}]},
+  {"company":"角星","city":"気仙沼市", "details":[
+    {"name":"金紋両國","kana_name":"きんもんりょうごく"}]},
+  {"company":"男山本店","city":"気仙沼市", "details":[
+    {"name":"伏見男山","kana_name":""}]},
+  {"company":"大沼酒造店","city":"柴田郡村田町", "details":[
+    {"name":"乾坤一","kana_name":"けんこんいち"}]},
+  {"company":"川敬商店","city":"遠田郡美里町", "details":[
+    {"name":"黄金澤","kana_name":"こがねさわ"}]},
+  {"company":"蔵王酒造","city":"白石市", "details":[
+    {"name":"蔵王","kana_name":"ざおう"}]},
+  {"company":"石越醸造","city":"登米市", "details":[
+    {"name":"澤乃泉","kana_name":"さわのいずみ"}]},
+  {"company":"大和蔵酒造","city":"黒川郡大和町", "details":[
+    {"name":"大和蔵","kana_name":"たいわぐら"},
+    {"name":"雪の松島","kana_name":"ゆきのまつしま"}]},
+  {"company":"内ヶ崎酒造店","city":"富谷市", "details":[
+    {"name":"鳳陽","kana_name":"ほうよう"},
+    {"name":"みやぎ萩","kana_name":"みやぎはぎ"}]},
+  {"company":"中勇酒造店","city":"加美郡加美町", "details":[
+    {"name":"鳴瀬川","kana_name":"なるせがわ"},
+    {"name":"天上夢幻","kana_name":"てんじょうむげん"},
+    {"name":"夢幻","kana_name":"むげん"}]},
+  {"company":"田中酒造店","city":"加美郡加美町", "details":[
+    {"name":"真鶴","kana_name":"まなつる"}]},
+  {"company":"山和酒造店","city":"加美郡加美町", "details":[
+    {"name":"わしが國","kana_name":"わしがくに"},
+    {"name":"瞑想水","kana_name":"めいそうすい"}]}
+]},
+{"name_n":"秋田県","city_r":[
+  {"company":"山本合名会社","city":"山本郡八峰町", "details":[
+    {"name":"白瀑","kana_name":"しらたき"}]},
+  {"company":"喜久水酒造","city":"能代市", "details":[
+    {"name":"喜久水","kana_name":"きくすい"}]},
+  {"company":"舞鶴酒造","city":"横手市", "details":[
+    {"name":"朝乃舞","kana_name":"あさのまい"}]},
+  {"company":"浅舞酒造","city":"横手市", "details":[
+    {"name":"天の戸","kana_name":"あまのと"}]},
+  {"company":"阿桜酒造","city":"横手市", "details":[
+    {"name":"かまくら","kana_name":"かまくら"}]},
+  {"company":"備前酒造","city":"横手市", "details":[
+    {"name":"大納川","kana_name":"だいながわ"}]},
+  {"company":"日の丸醸造","city":"横手市", "details":[
+    {"name":"まんさくの花","kana_name":"まんさくのはな"}]},
+  {"company":"刈穂酒造","city":"大仙市", "details":[
+    {"name":"刈穂","kana_name":"かりほ"}]},
+  {"company":"奥田酒造店","city":"大仙市", "details":[
+    {"name":"千代緑","kana_name":"ちよみどり"},
+    {"name":"超神ネイガーの酒","kana_name":""},
+    {"name":"だじゃく組合謹製の酒","kana_name":""}]},
+  {"company":"出羽鶴酒造","city":"大仙市", "details":[
+    {"name":"出羽鶴","kana_name":"でわつる"}]},
+  {"company":"鈴木酒造店","city":"大仙市", "details":[
+    {"name":"秀よし","kana_name":"ひでよし"},
+    {"name":"賢人","kana_name":"けんじん"}]},
+  {"company":"福乃友酒造","city":"大仙市", "details":[
+    {"name":"福乃友","kana_name":"ふくのとも"}]},
+  {"company":"金紋秋田酒造","city":"大仙市", "details":[
+    {"name":"山吹","kana_name":"やまぶき"}]},
+  {"company":"秋田誉酒造","city":"由利本荘市", "details":[
+    {"name":"秋田誉","kana_name":"あきたほまれ"}]},
+  {"company":"佐藤酒造店","city":"由利本荘市", "details":[
+    {"name":"出羽の冨士","kana_name":"でわのふじ"}]},
+  {"company":"天寿酒造","city":"由利本荘市", "details":[
+    {"name":"天寿","kana_name":"てんじゅ"}]},
+  {"company":"齋彌酒造店","city":"由利本荘市", "details":[
+    {"name":"由利正宗","kana_name":"ゆりまさむね"},
+    {"name":"雪の茅舎","kana_name":"ゆきのぼうしゃ"}]},
+  {"company":"新政酒造","city":"秋田市", "details":[
+    {"name":"新政","kana_name":"あらまさ"},
+    {"name":"吟華千輪","kana_name":"ぎんかせんりん"}]},
+  {"company":"秋田酒類製造","city":"秋田市", "details":[
+    {"name":"高清水","kana_name":"たかしみず"},
+    {"name":"しみずの舞","kana_name":"しみずのまい"}]},
+  {"company":"秋田県醗酵工業","city":"湯沢市", "details":[
+    {"name":"一滴千両","kana_name":"いってきせんりょう"}]},
+  {"company":"秋田銘醸","city":"湯沢市", "details":[
+    {"name":"爛漫","kana_name":"らんまん"}]},
+  {"company":"両関酒造","city":"湯沢市", "details":[
+    {"name":"両関","kana_name":"りょうぜき"}]},
+  {"company":"小玉醸造","city":"潟上市", "details":[
+    {"name":"太平山","kana_name":"たいへいざん"}]},
+  {"company":"栗林酒造店","city":"仙北郡美郷町", "details":[
+    {"name":"春霞","kana_name":"はるかすみ"}]},
+  {"company":"飛良泉本舗","city":"にかほ市", "details":[
+    {"name":"飛良泉","kana_name":"ひらいづみ"},
+    {"name":"欅倉","kana_name":"けやきぐら"},
+    {"name":"氷瓦","kana_name":"ひょうが"}]},
+  {"company":"福禄寿酒造","city":"南秋田郡五城目町", "details":[
+    {"name":"福祿寿","kana_name":"ふくろくじゅ"}]},
+  {"company":"北鹿","city":"大館市", "details":[
+    {"name":"北鹿","kana_name":"ほくしか"}]}
+]},
+{"name_n":"山形県","city_r":[
+  {"company":"オードヴィ庄内","city":"酒田市", "details":[
+    {"name":"金の蔵","kana_name":""},
+    {"name":"銀の蔵","kana_name":""},
+    {"name":"青の蔵","kana_name":""},
+    {"name":"飛翔","kana_name":""},
+    {"name":"浮世絵美人","kana_name":""},
+    {"name":"槽前酒","kana_name":""},
+    {"name":"清泉川","kana_name":""},
+    {"name":"占飲ひとりじめ","kana_name":""}]},
+  {"company":"酒田酒造","city":"酒田市", "details":[
+    {"name":"上喜元","kana_name":"じょうきげん"}]},
+  {"company":"東北銘醸","city":"酒田市", "details":[
+    {"name":"初孫","kana_name":"はつまご"},
+    {"name":"初孫 純米吟醸 いなほ","kana_name":""},
+    {"name":"初孫 純米本辛口 魔斬","kana_name":"まきり"},
+    {"name":"初孫 熟成酒 古酒三歳","kana_name":"こしゅさんさい"}]},
+  {"company":"加藤喜八郎酒造","city":"鶴岡市", "details":[
+    {"name":"大山 純米大吟醸 ため息といき ","kana_name":""},
+    {"name":"大山 特別純米 平成の宴","kana_name":"へいせいのうたげ"},
+    {"name":"貴一本","kana_name":""},
+    {"name":"ささの舞","kana_name":""},
+    {"name":"愛のすず風","kana_name":""},
+    {"name":"大希望","kana_name":""},
+    {"name":"飛切","kana_name":""}]},
+  {"company":"亀の井酒造","city":"鶴岡市", "details":[
+    {"name":"霊峰月山","kana_name":""},
+    {"name":"亀の井","kana_name":""},
+    {"name":"くどき上手","kana_name":""},
+    {"name":"酒未来","kana_name":""},
+    {"name":"出羽燦々","kana_name":""}]},
+  {"company":"小屋（こや）酒造","city":"最上郡大蔵村", "details":[
+    {"name":"大吟醸 絹","kana_name":""},
+    {"name":"吟醸 花羽陽","kana_name":"はなうよう"}]},
+  {"company":"月山酒造","city":"寒河江市", "details":[
+    {"name":"銀嶺月山 大吟醸 ","kana_name":"ぎんれい"},
+    {"name":"銀嶺月山 吟醸 月山の花","kana_name":"がっさんのはな"},
+    {"name":"銀嶺月山 吟醸 月天酔","kana_name":"つきてんすい"},
+    {"name":"銀嶺月山 純米吟醸 月山の雪","kana_name":""},
+    {"name":"銀嶺月山 本醸造 生原酒 槽前酒","kana_name":"ふなまえざけ"}]},
+  {"company":"千代寿虎屋酒造","city":"寒河江市", "details":[
+    {"name":"千代寿 純米 寒河江の荘","kana_name":""}]},
+  {"company":"古澤酒造","city":"寒河江市", "details":[
+    {"name":"紅花屋 重兵衛 大吟醸","kana_name":""}]},
+  {"company":"高木酒造","city":"村山市", "details":[
+    {"name":"十四代","kana_name":"じゅうよんだい"}]},
+  {"company":"六歌仙","city":"東根市", "details":[
+    {"name":"手間暇","kana_name":"てまひま"},
+    {"name":"六歌仙","kana_name":"ろっかせん"},
+    {"name":"山法師","kana_name":"やまほうし"},
+    {"name":"刻々","kana_name":"つれづれ"},
+    {"name":"大地響","kana_name":"だいちのひびき"}]},
+  {"company":"出羽桜（でわざくら）酒造","city":"天童市", "details":[
+    {"name":"出羽桜 純米吟醸 出羽燦々誕生記念","kana_name":"でわさんさんたんじょうきねん"},
+    {"name":"出羽桜 吟醸 桜花吟醸","kana_name":"おうかぎんじょう"},
+    {"name":"出羽桜 純米 一耕","kana_name":"いっこう"}]},
+  {"company":"男山酒造","city":"山形市", "details":[
+      {"name":"羽陽","kana_name":"うよう"},
+    {"name":"羽陽男山 純米大吟醸 澄天","kana_name":"ちょうてん"},
+    {"name":"羽陽男山 純米大吟醸 赤烏帽子","kana_name":"あかえぼし"},
+    {"name":"羽陽男山 純米吟醸 DEWA33夢がたり","kana_name":""}]},
+  {"company":"秀鳳（しゅうほう）酒造場","city":"山形市", "details":[
+    {"name":"秀鳳 大吟醸","kana_name":""},
+    {"name":"秀鳳 特別純米 雄町","kana_name":""},
+    {"name":"吟湶 純米吟醸","kana_name":""},
+    {"name":"庄五郎 特別本醸造","kana_name":""}]},
+  {"company":"寿虎屋酒造","city":"山形市", "details":[
+    {"name":"霞城寿大吟醸 寿久蔵","kana_name":""},
+    {"name":"霞城寿 大吟醸 雄町","kana_name":"おまち"},
+    {"name":"霞城寿 純米吟醸 DEWA33","kana_name":""},
+    {"name":"霞城寿 純米吟醸","kana_name":""},
+    {"name":"三百年の掟やぶり","kana_name":""}]},
+  {"company":"米鶴酒造","city":"東置賜郡高畠町", "details":[
+    {"name":"米鶴 大吟醸 巨匠","kana_name":"きょしょう"},
+    {"name":"米鶴 大吟醸 F1","kana_name":"えふわん"},
+    {"name":"米鶴 純米大吟醸 亀粋","kana_name":"きっすい"},
+    {"name":"米鶴 純米大吟醸 亀の尾","kana_name":"かめのお"},
+    {"name":"米鶴 純米大吟醸 自然流","kana_name":"じねんりゅう"},
+    {"name":"米鶴 純米吟醸 まほろば","kana_name":""}]},
+  {"company":"樽平（たるへい）酒造","city":"東置賜郡川西町", "details":[
+    {"name":"樽平 純米大吟醸","kana_name":""},
+    {"name":"住吉","kana_name":"すみよし"}]},
+  {"company":"渡會本店","city":"鶴岡市", "details":[
+    {"name":"出羽ノ雪","kana_name":""}]},
+  {"company":"小嶋総本店","city":"米沢市", "details":[
+    {"name":"東光","kana_name":"とうこう"},
+    {"name":"左利き","kana_name":""},
+    {"name":"東光レトロ","kana_name":""},
+    {"name":"花一輪 純米吟醸","kana_name":""},
+    {"name":"直江兼続公の前立て「愛」","kana_name":""},
+    {"name":"なせば成る","kana_name":""},
+    {"name":"米澤","kana_name":""},
+    {"name":"美味酒","kana_name":""},
+    {"name":"星の降る里","kana_name":""},
+    {"name":"ぽっちゃり美人スイート","kana_name":""},
+    {"name":"東光生酒","kana_name":""},
+    {"name":"東光上撰","kana_name":""},
+    {"name":"生貯蔵酒蔵出し原酒","kana_name":""},
+    {"name":"精撰鬼ころし","kana_name":""},
+    {"name":"吟醸生酒涼風だより","kana_name":""},
+    {"name":"桃色にごり酒","kana_name":""},
+    {"name":"枯恍酒","kana_name":""},
+    {"name":"秘蔵古酒","kana_name":""},
+    {"name":"東光正宗","kana_name":""},
+    {"name":"日本響","kana_name":""},
+    {"name":"洌","kana_name":""}]},
+  {"company":"加茂川酒造","city":"西置賜郡白鷹町", "details":[
+    {"name":"加茂川","kana_name":""},
+    {"name":"日の出加茂川","kana_name":""},
+    {"name":"久保桜","kana_name":""},
+    {"name":"瑞露鷹山","kana_name":""}]},
+  {"company":"野澤酒造店","city":"西置賜郡小国町", "details":[
+    {"name":"羽前桜川","kana_name":""}]},
+  {"company":"菊勇","city":"酒田市", "details":[
+    {"name":"秘伝","kana_name":""},
+    {"name":"蔵一番","kana_name":""},
+    {"name":"栄冠","kana_name":""}]},
+  {"company":"新藤酒造店","city":"米沢市", "details":[
+    {"name":"九郎左衛門","kana_name":"くろうざえもん"},
+    {"name":"雅山流","kana_name":"がざんりゅう"},
+    {"name":"裏・雅山流","kana_name":"うら・がざんりゅう"},
+    {"name":"千山万水","kana_name":""}]},
+  {"company":"鈴木酒造店長井蔵","city":"長井市", "details":[
+    {"name":"磐城壽","kana_name":"いわきことぶき"},
+    {"name":"一生幸福","kana_name":""},
+    {"name":"親父の小言","kana_name":""},
+    {"name":"土耕ん醸","kana_name":"どこんじょう"},
+    {"name":"鄙の影法師","kana_name":""},
+    {"name":"甦る","kana_name":""}]}
+]},
+{"name_n":"福島県","city_r":[
+  {"company":"榮川酒造","city":"会津若松市", "details":[
+    {"name":"榮川","kana_name":"えいせん"},
+    {"name":"榮四郎","kana_name":""},
+    {"name":"雷神光","kana_name":""},
+    {"name":"龍ケ沢","kana_name":""},
+    {"name":"磐梯しぼり","kana_name":""}]},
+  {"company":"名倉山酒造","city":"会津若松市", "details":[
+    {"name":"月弓","kana_name":"げっきゅう"},
+    {"name":"善き哉","kana_name":"よきかな"}]},
+  {"company":"高橋庄作酒造店","city":"会津若松市", "details":[
+    {"name":"会津娘","kana_name":""}]},
+  {"company":"花春酒造","city":"会津若松市", "details":[
+    {"name":"花春","kana_name":""},
+    {"name":"夢の香","kana_name":""},
+    {"name":"荒城の月","kana_name":""}]},
+  {"company":"宮泉銘醸","city":"会津若松市", "details":[
+    {"name":"宮泉","kana_name":"みやいずみ"},
+    {"name":"写楽","kana_name":"しゃらく"}]},
+  {"company":"末廣酒造","city":"会津若松市", "details":[
+    {"name":"末廣","kana_name":"すえひろ"},
+    {"name":"玄宰","kana_name":"げんさい"}]},
+  {"company":"鶴の江酒造","city":"会津若松市", "details":[
+    {"name":"会津中将","kana_name":"あいづちゅうしょう"},
+    {"name":"ゆり","kana_name":""}]},
+  {"company":"辰泉酒造","city":"会津若松市", "details":[
+    {"name":"京の華","kana_name":"きょうのはな"},
+    {"name":"会津流","kana_name":"あいづながれ"}]},
+  {"company":"山口合名会社","city":"会津若松市", "details":[
+    {"name":"会州一","kana_name":"かいしゅういち"}]},
+  {"company":"白井酒造","city":"会津美里町", "details":[
+    {"name":"萬代芳","kana_name":"ばんだいほう"}]},
+  {"company":"大和川酒造店","city":"喜多方市", "details":[
+    {"name":"弥右衛門","kana_name":"やえもん"},
+    {"name":"大和川","kana_name":"やまとがわ"},
+    {"name":"いのち","kana_name":""}]},
+  {"company":"ほまれ酒造","city":"喜多方市", "details":[
+    {"name":"会津ほまれ","kana_name":"あいづ"}]},
+  {"company":"夢心酒造","city":"喜多方市", "details":[
+    {"name":"夢心","kana_name":"ゆめごころ"},
+    {"name":"奈良萬","kana_name":"ならまん"},
+    {"name":"夢の香","kana_name":"ゆめのかおり"}]},
+  {"company":"小原酒造","city":"喜多方市", "details":[
+    {"name":"蔵粋","kana_name":"くらしっく"}]},
+  {"company":"峰の雪酒造場","city":"喜多方市", "details":[
+    {"name":"峰の雪","kana_name":"みねのゆき"}]},
+  {"company":"廣木酒造","city":"会津坂下町", "details":[
+    {"name":"泉川","kana_name":"いずみかわ"},
+    {"name":"飛露喜","kana_name":"ひろき"}]},
+  {"company":"曙酒造","city":"会津坂下町", "details":[
+    {"name":"天明","kana_name":"てんめい"},
+    {"name":"一生青春","kana_name":"いっしょうせいしゅん"}]},
+  {"company":"国権酒造","city":"南会津郡南会津町", "details":[
+    {"name":"國権","kana_name":"こっけん"}]},
+  {"company":"会津酒造","city":"南会津郡南会津町", "details":[
+    {"name":"金紋会津","kana_name":"きんもんあいづ"},
+    {"name":"凛","kana_name":"りん"}]},
+  {"company":"花泉酒造","city":"南会津郡南会津町", "details":[
+    {"name":"花泉","kana_name":"はないずみ"}]},
+  {"company":"稲川酒造","city":"耶麻郡猪苗代町", "details":[
+    {"name":"七重郎","kana_name":"しちじゅうろう"}]},
+  {"company":"磐梯酒造","city":"耶麻郡磐梯町", "details":[
+    {"name":"磐梯山","kana_name":"ばんだいさん"}]},
+  {"company":"金水晶酒造店","city":"福島市", "details":[
+    {"name":"金水晶","kana_name":"きんすいしょう"}]},
+  {"company":"奥の松酒造","city":"二本松市", "details":[
+    {"name":"奥の松","kana_name":"おくのまつ"}]},
+  {"company":"檜物屋酒造店","city":"二本松市", "details":[
+    {"name":"千功成","kana_name":"せんこうなり"}]},
+  {"company":"大七酒造","city":"二本松市", "details":[
+    {"name":"大七","kana_name":"だいしち"}]},
+  {"company":"人気酒造","city":"二本松市", "details":[
+    {"name":"人気一","kana_name":"にんきいち"}]},
+  {"company":"大天狗酒造","city":"本宮市", "details":[
+    {"name":"大天狗","kana_name":"だいてんぐ"},
+    {"name":"もとみや","kana_name":""},
+    {"name":"奥州二本松","kana_name":"おうしゅうにほんまつ"}]},
+  {"company":"佐藤酒造","city":"田村郡三春町", "details":[
+    {"name":"三春駒","kana_name":"みはるごま"}]},
+  {"company":"玄葉本店","city":"田村市", "details":[
+    {"name":"あぶくま","kana_name":""}]},
+  {"company":"仁井田本家","city":"郡山市", "details":[
+    {"name":"金宝自然酒","kana_name":"きんぽうしぜんしゅ"},
+    {"name":"穏","kana_name":"おだやか"}]},
+  {"company":"笹の川酒造","city":"郡山市", "details":[
+    {"name":"笹の川","kana_name":"ささのかわ"}]},
+  {"company":"渡辺酒造本店","city":"郡山市", "details":[
+    {"name":"雪小町","kana_name":"ゆきこまち"},
+    {"name":"雪村桜","kana_name":"せっそんざくら"}]},
+  {"company":"佐藤酒造店","city":"郡山市", "details":[
+    {"name":"藤乃井","kana_name":"ふじのい"}]},
+  {"company":"若関酒造","city":"郡山市", "details":[
+    {"name":"若関","kana_name":"わかぜき"}]},
+  {"company":"寿々乃井酒造店","city":"岩瀬郡天栄村", "details":[
+    {"name":"寿々乃井","kana_name":"すずのい"}]},
+  {"company":"松崎酒造天","city":"岩瀬郡天栄村", "details":[
+    {"name":"廣戸川","kana_name":"ひろとがわ"}]},
+  {"company":"千駒酒造","city":"白河市", "details":[
+    {"name":"千駒","kana_name":"せんこま"}]},
+  {"company":"大谷忠吉本店","city":"白河市", "details":[
+    {"name":"白陽","kana_name":"はくよう"}]},
+  {"company":"有賀醸造","city":"白河市", "details":[
+    {"name":"左馬","kana_name":"ひだりうま"}]},
+  {"company":"藤井酒造店","city":"東白川郡矢祭町", "details":[
+    {"name":"南郷","kana_name":"なんごう"}]},
+  {"company":"藤田屋本店","city":"東白川郡棚倉町", "details":[
+    {"name":"福賑榮","kana_name":"ふくにぎわい"}]},
+  {"company":"豊國酒造","city":"石川郡古殿町", "details":[
+    {"name":"東豊國","kana_name":"あずまとよくに"}]},
+  {"company":"若清水酒造","city":"石川郡平田村", "details":[
+    {"name":"若清水","kana_name":"わかしみず"}]},
+  {"company":"太平桜酒造","city":"いわき市", "details":[
+    {"name":"太平櫻","kana_name":"たいへいざくら"}]},
+  {"company":"四家酒造店","city":"いわき市", "details":[
+    {"name":"又兵衛","kana_name":"またべえ"}]},
+  {"company":"小野酒造店","city":"いわき市", "details":[
+    {"name":"四時川","kana_name":"しどきがわ"}]}
+]},
+{"name_n":"茨城県","city_r":[
+  {"company":"磯蔵酒造","city":"笠間市", "details":[
+    {"name":"稲里","kana_name":"いなさと"}]},
+  {"company":"笹目宗兵衛商店","city":"笠間市", "details":[
+    {"name":"二波山 松緑","kana_name":"まつみどり"}]},
+  {"company":"須藤本家株式会社","city":"笠間市", "details":[
+    {"name":"郷乃譽","kana_name":"さとのほまれ"}]},
+  {"company":"浦里酒造","city":"つくば市", "details":[
+    {"name":"霧筑波","kana_name":"きりつくば"}]},
+  {"company":"稲葉酒造","city":"つくば市", "details":[
+    {"name":"すてら","kana_name":""}]},
+  {"company":"安井酒造","city":"つくば市", "details":[
+    {"name":"住の江","kana_name":"すみのえ"}]},
+  {"company":"冨永酒造","city":"常陸太田市", "details":[
+    {"name":"剛烈","kana_name":"ごうれつ"}]},
+  {"company":"井坂酒造","city":"常陸太田市", "details":[
+    {"name":"日乃出鶴","kana_name":"ひのでつる"}]},
+  {"company":"岡部合名会社","city":"常陸太田市", "details":[
+    {"name":"松盛","kana_name":"まつざかり"}]},
+  {"company":"白菊酒造","city":"石岡市", "details":[
+    {"name":"白菊","kana_name":"しらぎく"}]},
+  {"company":"石岡酒造","city":"石岡市", "details":[
+    {"name":"白鹿","kana_name":"はくしか"},
+    {"name":"筑波","kana_name":"つくば"}]},
+  {"company":"府中誉酒造","city":"石岡市", "details":[
+    {"name":"渡舟","kana_name":"わたりぶね"}]},
+  {"company":"田中酒造","city":"取手市", "details":[
+    {"name":"君萬代","kana_name":"きみばんだい"}]},
+  {"company":"金門酒造","city":"取手市", "details":[
+    {"name":"金門","kana_name":"きんもん"}]},
+  {"company":"森島酒造","city":"日立市", "details":[
+    {"name":"大観","kana_name":"たいかん"}]},
+  {"company":"日渡酒造","city":"日立市", "details":[
+    {"name":"至寶","kana_name":"しほう"}]},
+  {"company":"野村醸造","city":"常総市", "details":[
+    {"name":"紬美人","kana_name":"つむぎびじん"}]},
+  {"company":"山中酒造店","city":"常総市", "details":[
+    {"name":"一人娘","kana_name":"ひとりむすめ"}]},
+  {"company":"吉久保酒造","city":"水戸市", "details":[
+    {"name":"一品","kana_name":"いっぴん"}]},
+  {"company":"瀧田酒造","city":"水戸市", "details":[
+    {"name":"三ツ扇","kana_name":"みつおおぎ"}]},
+  {"company":"村井醸造","city":"桜川市", "details":[
+    {"name":"公明","kana_name":"こうめい"}]},
+  {"company":"青木酒造","city":"古河市", "details":[
+    {"name":"御慶事","kana_name":"ごけいじ"}]},
+  {"company":"愛友酒造","city":"潮来市", "details":[
+    {"name":"友七","kana_name":"ともしち"}]},
+  {"company":"武勇","city":"結城市", "details":[
+    {"name":"武勇","kana_name":"ぶゆう"}]},
+  {"company":"結城酒造","city":"結城市", "details":[
+    {"name":"結","kana_name":"ゆい"},
+    {"name":"富久福","kana_name":"ふくふく"}]},
+  {"company":"来福酒造","city":"筑西市", "details":[
+    {"name":"来福","kana_name":"らいふく"}]}
+]},
+{"name_n":"栃木県","city_r":[
+  {"company":"鳳鸞酒造","city":"大田原市", "details":[
+    {"name":"鳳鸞","kana_name":"ほうらん"}]},
+  {"company":"天鷹酒造","city":"大田原市", "details":[
+    {"name":"天鷹","kana_name":"てんたか"}]},
+  {"company":"渡邊酒造","city":"大田原市", "details":[
+    {"name":"旭興","kana_name":"きょくこう"}]},
+  {"company":"菊の里酒造","city":"大田原市", "details":[
+    {"name":"菊の里","kana_name":"きくのさと"}]},
+  {"company":"池島酒造","city":"大田原市", "details":[
+    {"name":"池錦","kana_name":"いけにしき"}]},
+  {"company":"平山酒造店","city":"大田原市", "details":[
+    {"name":"藤の盛","kana_name":"ふじのもり"}]},
+  {"company":"宇都宮酒造","city":"宇都宮市", "details":[
+    {"name":"四季桜","kana_name":"しきざくら"}]},
+  {"company":"虎屋本店","city":"宇都宮市", "details":[
+    {"name":"菊","kana_name":"きく"}]},
+  {"company":"井上清吉商店","city":"宇都宮市", "details":[
+    {"name":"澤姫","kana_name":"さわひめ"}]},
+  {"company":"小林杢三郎商店","city":"宇都宮市", "details":[
+    {"name":"大英勇","kana_name":"だいえいゆう"}]},
+  {"company":"外池荘五郎商店","city":"宇都宮市", "details":[
+    {"name":"東錦","kana_name":"あずまにしき"}]},
+  {"company":"小林酒造","city":"小山市", "details":[
+    {"name":"鳳凰金賞","kana_name":"ほうおうきんしょう"},
+    {"name":"鳳凰美田","kana_name":"ほうおうびでん"}]},
+  {"company":"三福酒造","city":"小山市", "details":[
+    {"name":"三福","kana_name":"さんぷく"}]},
+  {"company":"杉田酒造","city":"小山市", "details":[
+    {"name":"雄東正宗","kana_name":"ゆうとうまさむね"}]},
+  {"company":"西堀酒造","city":"小山市", "details":[
+    {"name":"若盛","kana_name":"わかさかり"},
+    {"name":"門外不出","kana_name":"もんがいふしゅつ"}]},
+  {"company":"若駒酒造","city":"小山市", "details":[
+    {"name":"若駒","kana_name":"わかこま"}]},
+  {"company":"相沢酒造","city":"佐野市", "details":[
+    {"name":"愛乃澤","kana_name":"あいのさわ"}]},
+  {"company":"第一酒造","city":"佐野市", "details":[
+    {"name":"開華","kana_name":"かいか"}]},
+  {"company":"吉井酒造","city":"佐野市", "details":[
+    {"name":"初戎","kana_name":"はつえびす"}]},
+  {"company":"星野酒造","city":"栃木市", "details":[
+    {"name":"国光正宗","kana_name":"こっこうまさむね"}]},
+  {"company":"北関酒造","city":"栃木市", "details":[
+    {"name":"北冠","kana_name":"ほっかん"}]},
+  {"company":"渡邊佐平商店","city":"日光市", "details":[
+    {"name":"清開","kana_name":"せいかい"}]},
+  {"company":"片山酒造","city":"日光市", "details":[
+    {"name":"柏盛","kana_name":"かしわざかり"}]},
+  {"company":"森戸酒造","city":"矢板市", "details":[
+    {"name":"十一正宗","kana_name":"じゅういちまさむね"}]},
+  {"company":"富川酒造店","city":"矢板市", "details":[
+    {"name":"忠愛","kana_name":"ちゅうあい"}]},
+  {"company":"松井酒造店","city":"塩谷郡塩谷町", "details":[
+    {"name":"松の寿","kana_name":"まつのことぶき"}]},
+  {"company":"小島酒造店","city":"塩谷郡塩谷町", "details":[
+    {"name":"かんなびの里","kana_name":"かんなびのさと"}]},
+  {"company":"阿部酒造店","city":"芳賀郡茂木町", "details":[
+    {"name":"千代の白菊","kana_name":"ちよのしらぎく"}]},
+  {"company":"辻善兵衛商店","city":"真岡市", "details":[
+    {"name":"桜川","kana_name":"さくらがわ"}]},
+  {"company":"熊久保商店","city":"那須塩原市", "details":[
+    {"name":"那須野泉","kana_name":"なすのいずみ"}]},
+  {"company":"仙禽酒造","city":"さくら市", "details":[
+    {"name":"仙禽","kana_name":"せんきん"}]},
+  {"company":"島崎酒造","city":"那須烏山市", "details":[
+    {"name":"東力士","kana_name":"あずまりきし"}]},
+  {"company":"白相酒造","city":"那須郡那珂川町", "details":[
+    {"name":"福寿松の井","kana_name":"ふくじゅまつのい"}]},
+  {"company":"惣誉酒造","city":"芳賀郡市貝町", "details":[
+    {"name":"惣誉","kana_name":"そうほまれ"}]},
+  {"company":"外池酒造店","city":"芳賀郡益子町", "details":[
+    {"name":"燦爛","kana_name":"さんらん"}]},
+  {"company":"飯沼銘醸","city":"栃木市", "details":[
+    {"name":"杉並木","kana_name":"すぎなみき"}]},
+  {"company":"大平酒造","city":"栃木市", "details":[
+    {"name":"黒龍","kana_name":"こくりゅう"}]},
+  {"company":"相良酒造","city":"栃木市", "details":[
+    {"name":"朝日栄","kana_name":"あさひさかえ"}]}
+]},
+{"name_n":"群馬県","city_r":[
+  {"company":"今井酒造店","city":"", "details":[
+    {"name":"上州風まかせ","kana_name":"じょうしゅうかぜまかせ"}]},
+  {"company":"近藤酒造","city":"みどり市", "details":[
+    {"name":"赤城山","kana_name":"あかぎさん"}]},
+  {"company":"龍神酒造","city":"館林市", "details":[
+    {"name":"尾瀬の雪どけ","kana_name":"おぜのゆきどけ"}]},
+  {"company":"龍神酒造","city":"館林市", "details":[
+    {"name":"龍神","kana_name":"りゅうじん"}]},
+  {"company":"島岡酒造","city":"太田市", "details":[
+    {"name":"群馬泉","kana_name":"ぐんまいずみ"}]},
+  {"company":"井田酒造","city":"佐波郡玉村町", "details":[
+    {"name":"不盡泉","kana_name":"ふじいずみ"}]},
+  {"company":"高井","city":"藤岡市", "details":[
+    {"name":"巌","kana_name":"いわお"}]},
+  {"company":"松屋酒造","city":"藤岡市", "details":[
+    {"name":"當選","kana_name":"とうせん"}]},
+  {"company":"岡村","city":"高崎市", "details":[
+    {"name":"泉末廣","kana_name":"いずみすえひろ"}]},
+  {"company":"牧野酒造","city":"高崎市", "details":[
+    {"name":"大盃","kana_name":"おおさかずき"}]},
+  {"company":"野田酒造店","city":"前橋市", "details":[
+    {"name":"加茂川","kana_name":"かもがわ"}]},
+  {"company":"七ッ星醸造","city":"前橋市", "details":[
+    {"name":"暴れ獅子","kana_name":"あばれじし"}]},
+  {"company":"柳沢酒造","city":"前橋市", "details":[
+    {"name":"桂川","kana_name":"かつらがわ"}]},
+  {"company":"柿崎屋馬場酒造","city":"前橋市", "details":[
+    {"name":"群馬誉","kana_name":"ぐんまほまれ"}]},
+  {"company":"柴崎酒造","city":"北群馬郡吉岡町", "details":[
+    {"name":"船尾瀧","kana_name":"ふなおたき"}]},
+  {"company":"聖酒造","city":"渋川市", "details":[
+    {"name":"関東の華","kana_name":"かんとうのはな"}]},
+  {"company":"永井本家","city":"沼田市", "details":[
+    {"name":"利根錦","kana_name":"とねにしき"}]},
+  {"company":"永井酒造","city":"利根郡川場村", "details":[
+    {"name":"水芭蕉","kana_name":"みずばしょう"}]},
+  {"company":"永井酒造","city":"利根郡川場村", "details":[
+    {"name":"谷川岳","kana_name":"たにがわだけ"}]},
+  {"company":"永井酒造","city":"利根郡川場村", "details":[
+    {"name":"力鶴","kana_name":"ちからつる"}]},
+  {"company":"土田酒造","city":"利根郡川場村", "details":[
+    {"name":"誉國光","kana_name":"ほまれこっこう"}]},
+  {"company":"貴娘酒造","city":"吾妻郡中之条町", "details":[
+    {"name":"貴娘","kana_name":"きむすめ"}]},
+  {"company":"浅間酒造","city":"吾妻郡長野原町", "details":[
+    {"name":"秘幻","kana_name":"ひげん"}]}
+]},
+{"name_n":"埼玉県","city_r":[
+  {"company":"南陽醸造株式会社","city":"羽生市", "details":[
+    {"name":"花陽浴","kana_name":"はなあび"}]},
+  {"company":"株式会社東亜酒造","city":"羽生市", "details":[
+    {"name":"晴菊武州","kana_name":"はれぎくぶしゅう"}]},
+  {"company":"株式会社釜屋","city":"加須市", "details":[
+    {"name":"力士","kana_name":"りきし"}]},
+  {"company":"清水酒造株式会社","city":"加須市", "details":[
+    {"name":"花菱","kana_name":"はなびし"}]},
+  {"company":"神亀酒造","city":"蓮田市", "details":[
+    {"name":"神亀","kana_name":"しんかめ"},
+    {"name":"ひこ孫","kana_name":"ひこまご"},
+    {"name":"仙亀","kana_name":"せんかめ"}]},
+  {"company":"清龍酒造","city":"蓮田市", "details":[
+    {"name":"清龍","kana_name":"せいりゅう"}]},
+  {"company":"寒梅酒造","city":"久喜市", "details":[
+    {"name":"寒梅","kana_name":"かんばい"}]},
+  {"company":"石井酒造株式会社","city":"幸手市", "details":[
+    {"name":"豊明","kana_name":"ほうめい"}]},
+  {"company":"内木酒造株式会社","city":"さいたま市桜区", "details":[
+    {"name":"旭正宗","kana_name":"あさひまさむね"}]},
+  {"company":"大瀧酒造","city":"さいたま市見沼区", "details":[
+    {"name":"九重桜","kana_name":"ここのえさくら"}]},
+  {"company":"株式会社小山本家酒造","city":"さいたま市西区", "details":[
+    {"name":"金紋世界鷹","kana_name":"きんもんせかいたか"}]},
+  {"company":"鈴木酒造株式会社","city":"さいたま市岩槻区", "details":[
+    {"name":"万両","kana_name":"まんりょう"}]},
+  {"company":"株式会社文楽","city":"上尾市", "details":[
+    {"name":"文楽","kana_name":"ぶんらく"}]},
+  {"company":"麻原酒造株式会社","city":"入間郡毛呂山町", "details":[
+    {"name":"琵琶のさゝ浪","kana_name":"びわのさざなみ"}]},
+  {"company":"有限会社佐藤酒造店","city":"入間郡越生町", "details":[
+    {"name":"越生梅林","kana_name":"おごせばいりん"}]},
+  {"company":"越生酒造合資会社","city":"入間郡越生町", "details":[
+    {"name":"来陽","kana_name":"らいよう"}]},
+  {"company":"小江戸鏡山酒造株式会社","city":"川越市", "details":[
+    {"name":"鏡山","kana_name":"かがみやま"}]},
+  {"company":"五十嵐酒造","city":"飯能市", "details":[
+    {"name":"天覧山","kana_name":"てんらんざん"}]},
+  {"company":"武蔵鶴酒造株式会社","city":"比企郡小川町", "details":[
+    {"name":"武蔵鶴","kana_name":"むさしつる"}]},
+  {"company":"晴雲酒造株式会社","city":"比企郡小川町", "details":[
+    {"name":"晴雲","kana_name":"せいうん"}]},
+  {"company":"松岡酒造株式会社","city":"比企郡小川町", "details":[
+    {"name":"帝松","kana_name":"みかどまつ"}]},
+  {"company":"矢尾本店","city":"秩父市", "details":[
+    {"name":"秩父錦","kana_name":"ちちぶにしき"}]},
+  {"company":"武甲酒造","city":"秩父市", "details":[
+    {"name":"武甲正宗","kana_name":"ぶこうまさむね"}]},
+  {"company":"秩父菊水酒造株式会社","city":"秩父市", "details":[
+    {"name":"秩父小次郎","kana_name":"ちちぶこじろう"}]},
+  {"company":"権田酒造株式会社","city":"熊谷市", "details":[
+    {"name":"直実","kana_name":"なおざね"}]},
+  {"company":"滝澤酒造株式会社","city":"深谷市", "details":[
+    {"name":"菊泉","kana_name":"きくいずみ"}]},
+  {"company":"丸山酒造株式会社","city":"深谷市", "details":[
+    {"name":"金大星正宗","kana_name":"きんたいぼしまさむね"}]},
+  {"company":"株式会社藤橋藤三郎商店","city":"深谷市", "details":[
+    {"name":"東白菊","kana_name":"あずましらぎく"}]},
+  {"company":"株式会社藤﨑摠兵衛商店","city":"大里郡寄居町", "details":[
+    {"name":"白扇","kana_name":"はくせん"}]},
+  {"company":"川端酒造","city":"行田市", "details":[
+    {"name":"桝川","kana_name":"ますかわ"}]},
+  {"company":"横田酒造株式会社","city":"行田市", "details":[
+    {"name":"日本橋","kana_name":"にほんばし"}]},
+  {"company":"長澤酒造株式会社","city":"日高市", "details":[
+    {"name":"高麗王","kana_name":"こまおう"}]},
+  {"company":"株式会社横関酒造店","city":"児玉郡美里町", "details":[
+    {"name":"天仁","kana_name":"てんじん"}]},
+  {"company":"関口酒造合名会社","city":"北葛飾郡杉戸町", "details":[
+    {"name":"杉戸宿","kana_name":"すぎとじゅく"}]},
+  {"company":"有馬錦酒造株式会社","city":"飯能市", "details":[
+    {"name":"有馬錦","kana_name":"ありまにしき"}]}
+]},
+{"name_n":"千葉県","city_r":[
+  {"company":"飯田本家","city":"香取市", "details":[
+    {"name":"大姫","kana_name":"おおひめ"}]},
+  {"company":"東薫酒造","city":"香取市", "details":[
+    {"name":"東薫","kana_name":"とうくん"},
+    {"name":"叶","kana_name":"かのう"},
+    {"name":"卯兵衛の酒","kana_name":"うへえのさけ"},
+    {"name":"二人静","kana_name":"ふたりしずか"},
+    {"name":"夢と幻の物語","kana_name":"ゆめとまぼろしのものがたり"}]},
+  {"company":"馬場本店","city":"香取市", "details":[
+    {"name":"雪山","kana_name":"せつざん"},
+    {"name":"海舟散人","kana_name":"かいしゅうさんじん"}]},
+  {"company":"寺田本家","city":"香取郡神崎町", "details":[
+    {"name":"五人娘","kana_name":"ごにんむすめ"},
+    {"name":"香取","kana_name":"かとり"}]},
+  {"company":"鍋店","city":"香取郡神崎町", "details":[
+    {"name":"仁勇","kana_name":"じんゆう"},
+    {"name":"不動","kana_name":"ふどう"}]},
+  {"company":"滝沢本店","city":"成田市", "details":[
+    {"name":"長命泉","kana_name":"ちょうめいせん"}]},
+  {"company":"飯沼本家","city":"酒々井町", "details":[
+    {"name":"甲子正宗","kana_name":"きのえねまさむね"}]},
+  {"company":"小林酒造","city":"銚子市", "details":[
+    {"name":"祥兆","kana_name":"しょうちょう"}]},
+  {"company":"飯田酒造場","city":"銚子市", "details":[
+    {"name":"徳明","kana_name":"とくめい"}]},
+  {"company":"石上酒造","city":"銚子市", "details":[
+    {"name":"銚子の誉","kana_name":"ちょうしのほまれ"}]},
+  {"company":"旭鶴 田中酒造店","city":"佐倉市", "details":[
+    {"name":"旭鶴","kana_name":"あさひづる"},
+    {"name":"佐倉城","kana_name":"さくらじょう"}]},
+  {"company":"宮崎酒造店","city":"君津市", "details":[
+    {"name":"峯の精","kana_name":"みねのせい"}]},
+  {"company":"須藤本家","city":"君津市", "details":[
+    {"name":"天乃原","kana_name":"あまのはら"}]},
+  {"company":"藤平酒造","city":"君津市", "details":[
+    {"name":"福祝","kana_name":"ふくいわい"}]},
+  {"company":"池田商店","city":"富津市", "details":[
+    {"name":"聖泉","kana_name":"せいせん"}]},
+  {"company":"守屋酒造","city":"山武市", "details":[
+    {"name":"舞桜","kana_name":"まいざくら"},
+    {"name":"しだれ桜","kana_name":"しだれざくら"},
+    {"name":"平安桜","kana_name":"平安桜"},
+    {"name":"浪花盛","kana_name":"なにわざかり"}]},
+  {"company":"寒菊銘醸","city":"山武市", "details":[
+    {"name":"総乃寒菊","kana_name":"ふさのかんぎく"},
+    {"name":"夢の又夢","kana_name":"ゆめのまたゆめ"}]},
+  {"company":"花の友","city":"山武市", "details":[
+    {"name":"花いちもんめ","kana_name":"はないちもんめ"}]},
+  {"company":"梅一輪酒造","city":"山武市", "details":[
+    {"name":"梅一輪","kana_name":"うめいちりん"}]},
+  {"company":"稲花酒造","city":"長生郡一宮町", "details":[
+    {"name":"稲花正宗","kana_name":"いなはなまさむね"},
+    {"name":"金龍稲花","kana_name":"きんりゅういなはな"}]},
+  {"company":"木戸泉酒造","city":"いすみ市", "details":[
+    {"name":"木戸泉","kana_name":"きどいずみ"},
+    {"name":"アフス","kana_name":"あふす）古"}]},
+  {"company":"東灘醸造","city":"勝浦市", "details":[
+    {"name":"東灘","kana_name":"あづまなだ"}]},
+  {"company":"吉野酒造","city":"勝浦市", "details":[
+    {"name":"腰古井","kana_name":"こしごい"}]},
+  {"company":"豊乃鶴酒造","city":"夷隅郡大多喜町", "details":[
+    {"name":"大多喜城","kana_name":"おおたきじょう"}]},
+  {"company":"岩瀬酒造","city":"夷隅郡御宿町", "details":[
+    {"name":"岩の井","kana_name":"いわのい"}]},
+  {"company":"亀田酒造","city":"鴨川市", "details":[
+    {"name":"寿萬亀","kana_name":"じゅまんがめ"},
+    {"name":"見返り美人","kana_name":"みかえりびじん"}]}
+]},
+{"name_n":"東京都","city_r":[
+  {"company":"野崎酒造","city":"あきる野市", "details":[
+    {"name":"喜正","kana_name":"きしょう"}]},
+  {"company":"中村酒造","city":"あきる野市", "details":[
+    {"name":"千代鶴","kana_name":"ちよつる"}]},
+  {"company":"豊島屋酒造","city":"東村山市", "details":[
+    {"name":"金婚正宗","kana_name":"きんこんまさむね"},
+    {"name":"屋守","kana_name":"おくのかみ"}]},
+  {"company":"野口酒造店","city":"府中市", "details":[
+    {"name":"国府鶴","kana_name":"こうづる"}]},
+  {"company":"小澤酒造","city":"青梅市", "details":[
+    {"name":"澤乃井","kana_name":"さわのい"}]},
+  {"company":"石川酒造","city":"福生市", "details":[
+    {"name":"多満自慢","kana_name":"たまじまん"}]},
+  {"company":"田村酒造場","city":"福生市", "details":[
+    {"name":"嘉泉","kana_name":"かせん"}]},
+  {"company":"東京港醸造","city":"港区", "details":[
+    {"name":"江戸開城 ","kana_name":"えどかいじょう"}]},
+  {"company":"小山酒造","city":"北区", "details":[
+    {"name":"丸眞正宗","kana_name":"まるしんまさむね"}]},
+  {"company":"小澤酒造場","city":"八王子市", "details":[
+    {"name":"桑乃都","kana_name":"くわのみやこ"}]}
+]},
+{"name_n":"神奈川県","city_r":[
+  {"company":"神奈川県央酒販協同組合 相模原酒販協同組合","city":"厚木市 海老名市 相模原市", "details":[
+    {"name":"丹沢ほまれ","kana_name":"たんざわほまれ"}]},
+  {"company":"泉橋酒造","city":"海老名市下今泉", "details":[
+    {"name":"いづみ橋","kana_name":"いづみばし"}]},
+  {"company":"吉川醸造","city":"伊勢原市神戸", "details":[
+    {"name":"菊勇","kana_name":"きくゆう"}]},
+  {"company":"黄金井酒造","city":"厚木市", "details":[
+    {"name":"盛升","kana_name":"さかります"},
+    {"name":"森のかけ橋","kana_name":"もりのかけはし"},
+    {"name":"和酒","kana_name":"わしゅ"},
+    {"name":"蔵出し","kana_name":"くらだし"}]},
+  {"company":"金井酒造店","city":"秦野市", "details":[
+    {"name":"白笹つづみ","kana_name":"しろささつづみ"},
+    {"name":"鳳泉","kana_name":"おおとりいずみ"},
+    {"name":"若水","kana_name":"わかみず"},
+    {"name":"無農薬自然酒","kana_name":"むのうやくしぜんしゅ"},
+    {"name":"神奈川物語","kana_name":"かながわものがたり"},
+    {"name":"白笹","kana_name":"しろささ"},
+    {"name":"白笹鼓","kana_name":"しろささつづみ"}]},
+  {"company":"中澤酒造","city":"松田町", "details":[
+    {"name":"松美酉","kana_name":"まつみどり"},
+    {"name":"亮","kana_name":"りょう"},
+    {"name":"四季の箱根","kana_name":"しきのはこね"}]},
+  {"company":"石井醸造","city":"足柄上郡大井町", "details":[
+    {"name":"曽我の誉","kana_name":"そがのほまれ"},
+    {"name":"箱根寒梅","kana_name":"はこねかんばい"}]},
+  {"company":"舞姿酒造","city":"南足柄市岩原", "details":[
+    {"name":"舞姿","kana_name":"まいすがた"}]},
+  {"company":"金井酒造店","city":"秦野市", "details":[
+    {"name":"モーツァルト","kana_name":"もーつぁると"}]},
+  {"company":"清水酒造","city":"相模原市", "details":[
+    {"name":"巌の泉","kana_name":"いわおのいずみ"},
+    {"name":"保土ヶ谷宿","kana_name":"ほどがやじゅく"},
+    {"name":"船越","kana_name":"ふなこし"}]},
+  {"company":"熊澤酒造","city":"茅ヶ崎市", "details":[
+    {"name":"天青","kana_name":"てんせい"}]},
+  {"company":"川西屋酒造店","city":"山北町", "details":[
+    {"name":"隆 ","kana_name":"りゅう"},
+    {"name":"丹沢山","kana_name":"たんざわさん"}]}
+]},
+{"name_n":"新潟県","city_r":[
+  {"company":"大洋酒造","city":"村上市", "details":[
+    {"name":"大洋盛","kana_name":"たいようざかり"}]},
+  {"company":"宮尾酒造","city":"村上市", "details":[
+    {"name":"〆張鶴","kana_name":"しめはりつる"}]},
+  {"company":"尾畑酒造","city":"佐渡市", "details":[
+    {"name":"真野鶴","kana_name":"まのづる"}]},
+  {"company":"加藤酒造店","city":"佐渡市", "details":[
+    {"name":"金鶴","kana_name":"きんつる"}]},
+  {"company":"佐渡銘醸","city":"佐渡市", "details":[
+    {"name":"天領盃","kana_name":"てんりょうはい"}]},
+  {"company":"北雪酒造","city":"佐渡市", "details":[
+    {"name":"北雪","kana_name":"ほくせつ"},
+    {"name":"佐渡のきりょうよし","kana_name":"さどのきりょうよし"}]},
+  {"company":"市島酒造","city":"新発田市", "details":[
+    {"name":"王紋","kana_name":"おうもん"}]},
+  {"company":"菊水酒造","city":"新発田市", "details":[
+    {"name":"菊水","kana_name":"きくすい"}]},
+  {"company":"金升酒造","city":"新発田市", "details":[
+    {"name":"初花","kana_name":"はつはな"}]},
+  {"company":"ふじの井酒造","city":"新発田市", "details":[
+    {"name":"ふじの井","kana_name":"ふじのい"}]},
+  {"company":"越後酒造場","city":"新潟市北区", "details":[
+    {"name":"甘雨","kana_name":"かんう"}]},
+  {"company":"越後伝衛門","city":"新潟市北区", "details":[
+    {"name":"伝衛門","kana_name":"でんえもん"}]},
+  {"company":"小黒酒造","city":"新潟市北区", "details":[
+    {"name":"越乃梅里","kana_name":"こしのばいり"}]},
+  {"company":"越の華酒造","city":"新潟市中央区", "details":[
+    {"name":"越の華","kana_name":"こしのはな"}]},
+  {"company":"高野酒造","city":"新潟市西区", "details":[
+    {"name":"越路吹雪","kana_name":"こしじふぶき"}]},
+  {"company":"塩川酒造","city":"新潟市西区", "details":[
+    {"name":"越の関","kana_name":"こしのせき"}]},
+  {"company":"樋木酒造","city":"新潟市西区", "details":[
+    {"name":"鶴乃友","kana_name":"つるのとも"}]},
+  {"company":"石本酒造","city":"新潟市江南区", "details":[
+    {"name":"越乃寒梅","kana_name":"こしのかんばい"}]},
+  {"company":"村祐酒造","city":"新潟市秋葉区", "details":[
+    {"name":"村祐","kana_name":"むらゆう"}]},
+  {"company":"上原酒造","city":"新潟市西蒲区", "details":[
+    {"name":"越後鶴亀","kana_name":"えちごつるかめ"}]},
+  {"company":"笹祝酒造","city":"新潟市西蒲区", "details":[
+    {"name":"笹祝","kana_name":"ささいわい"}]},
+  {"company":"福井酒造","city":"新潟市西蒲区", "details":[
+    {"name":"峰乃白梅","kana_name":"みねのはくばい"}]},
+  {"company":"越つかの酒造","city":"阿賀野市", "details":[
+    {"name":"越のあじわい","kana_name":"こしのあじわい"}]},
+  {"company":"越の日本桜酒造","city":"阿賀野市", "details":[
+    {"name":"越の日本桜","kana_name":"こしのにほんざくら"}]},
+  {"company":"白龍酒造","city":"阿賀野市", "details":[
+    {"name":"白龍","kana_name":"はくりゅう"}]},
+  {"company":"金鵄盃酒造","city":"五泉市", "details":[
+    {"name":"越後杜氏","kana_name":"えちごとうじ"}]},
+  {"company":"近藤酒造","city":"五泉市", "details":[
+    {"name":"酔星","kana_name":"すいせい"}]},
+  {"company":"下越酒造","city":"東蒲原郡阿賀町", "details":[
+    {"name":"麒麟","kana_name":"きりん"}]},
+  {"company":"麒麟山酒造","city":"東蒲原郡阿賀町", "details":[
+    {"name":"麒麟山","kana_name":"きりんざん"}]},
+  {"company":"加茂錦酒造","city":"加茂市", "details":[
+    {"name":"加茂錦","kana_name":"かもにしき"}]},
+  {"company":"マスカガミ","city":"加茂市", "details":[
+    {"name":"萬寿鏡","kana_name":"ますかがみ"}]},
+  {"company":"雪椿酒造","city":"加茂市", "details":[
+    {"name":"雪椿","kana_name":"ゆきつばき"}]},
+  {"company":"福顔酒造","city":"三条市", "details":[
+    {"name":"福顔","kana_name":"ふくがお"},
+    {"name":"五十嵐川","kana_name":"いからしがわ"}]},
+  {"company":"朝日酒造","city":"長岡市", "details":[
+    {"name":"朝日山","kana_name":"あさひやま"},
+    {"name":"越州","kana_name":"えつしゅう"},
+    {"name":"久保田","kana_name":"くぼた"},
+    {"name":"越のかぎろひ","kana_name":"こしのかぎろひ"}]},
+  {"company":"お福酒造","city":"長岡市", "details":[
+    {"name":"お福正宗","kana_name":"おふくまさむね"},
+    {"name":"山古志","kana_name":"やまこし"}]},
+  {"company":"久須美酒造","city":"長岡市", "details":[
+    {"name":"清泉","kana_name":"きよいずみ"},
+    {"name":"祝鶴亀","kana_name":"いわいつるかめ"},
+    {"name":"亀の翁","kana_name":"かめのお"},
+    {"name":"亀の尾","kana_name":"かめのお"},
+    {"name":"夏子物語","kana_name":"なつこものがたり"}]},
+  {"company":"栃倉酒造","city":"長岡市", "details":[
+    {"name":"米百俵","kana_name":"こめひゃっぴょう"}]},
+  {"company":"諸橋酒造","city":"長岡市", "details":[
+    {"name":"越乃景虎","kana_name":"こしのかげとら"}]},
+  {"company":"吉乃川","city":"長岡市", "details":[
+    {"name":"吉乃川","kana_name":"よしのがわ"},
+    {"name":"霊泉汲尽","kana_name":"れいせんくめどもつきづ"},
+    {"name":"佐渡小判","kana_name":"さどこばん"}]},
+  {"company":"石塚酒造","city":"柏崎市", "details":[
+    {"name":"姫の井","kana_name":"ひめのい"}]},
+  {"company":"原酒造","city":"柏崎市", "details":[
+    {"name":"越の誉","kana_name":"こしのほまれ"}]},
+  {"company":"新潟銘醸","city":"小千谷市", "details":[
+    {"name":"越後の長者","kana_name":"えちごのちょうじゃ"},
+    {"name":"越の寒中梅","kana_name":"こしのかんちゅうばい"},
+    {"name":"越乃花霞","kana_name":"こしのはながすみ"},
+    {"name":"長者盛","kana_name":"ちょうじゃざかり"}]},
+  {"company":"玉川酒造","city":"魚沼市", "details":[
+    {"name":"玉風味","kana_name":"たまふうみ"}]},
+  {"company":"緑川酒造","city":"魚沼市", "details":[
+    {"name":"緑川","kana_name":"みどりかわ"}]},
+  {"company":"青木酒造","city":"南魚沼市", "details":[
+    {"name":"鶴齢","kana_name":"かくれい"},
+    {"name":"雪国の酒「雪男」","kana_name":"ゆきぐにのさけ ゆきおとこ"}]},
+  {"company":"高千代酒造","city":"南魚沼市", "details":[
+    {"name":"高千代","kana_name":"たかちよ"},
+    {"name":"巻機","kana_name":"まきはた"},
+    {"name":"天地人","kana_name":"てんちじん"},
+    {"name":"兼続","kana_name":"かねつぐ"}]},
+  {"company":"八海醸造","city":"南魚沼市", "details":[
+    {"name":"八海山","kana_name":"はっかいさん"}]},
+  {"company":"魚沼酒造","city":"十日町市", "details":[
+    {"name":"天神囃子","kana_name":"てんじんばやし"}]},
+  {"company":"松乃井酒造場","city":"十日町市", "details":[
+    {"name":"松乃井","kana_name":"まつのい"}]},
+  {"company":"加茂の井酒造","city":"上越市板倉区", "details":[
+    {"name":"加茂の井","kana_name":"かものい"}]},
+  {"company":"田中酒造","city":"上越市", "details":[
+    {"name":"能鷹","kana_name":"能鷹"}]},
+  {"company":"丸山酒造場","city":"上越市三和区", "details":[
+    {"name":"雪中梅","kana_name":"せっちゅうばい"}]},
+  {"company":"妙高酒造","city":"上越市", "details":[
+    {"name":"妙高山","kana_name":"みょうこうさん"}]},
+  {"company":"武蔵野酒造","city":"上越市", "details":[
+    {"name":"スキー正宗","kana_name":"すきーまさむね"}]},
+  {"company":"よしかわ杜氏の郷","city":"上越市吉川区", "details":[
+    {"name":"有りがたし","kana_name":"ありがたし"},
+    {"name":"天恵楽","kana_name":"てんけいらく"},
+    {"name":"よしかわ杜氏","kana_name":"よしかわ杜氏"}]},
+  {"company":"池田屋酒造","city":"糸魚川市", "details":[
+    {"name":"謙信","kana_name":"けんしん"}]},
+  {"company":"加賀の井酒造","city":"糸魚川市", "details":[
+    {"name":"加賀の井","kana_name":"かがのい"}]},
+  {"company":"渡辺酒造店","city":"糸魚川市", "details":[
+    {"name":"根知男山","kana_name":"ねちおとこやま"}]},
+  {"company":"君の井酒造","city":"妙高市", "details":[
+    {"name":"君の井","kana_name":"きみのい"}]},
+  {"company":"千代の光酒造","city":"妙高市", "details":[
+    {"name":"千代の光","kana_name":"ちよのひかり"}]},
+  {"company":"滝澤酒造","city":"中魚沼郡津南町", "details":[
+    {"name":"苗場山","kana_name":"なえばさん"}]},
+  {"company":"津南醸造","city":"津南町", "details":[
+    {"name":"霧の塔","kana_name":"きりのとう"}]},
+  {"company":"白瀧酒造","city":"南魚沼郡湯沢町", "details":[
+    {"name":"白瀧","kana_name":"しらたき"},
+    {"name":"上善如水","kana_name":"じょうぜんみずのごとし"}]}
+]},
+{"name_n":"富山県","city_r":[
+  {"company":"株式会社桝田酒造店","city":"富山市", "details":[
+    {"name":"満寿泉","kana_name":"ますいずみ"}]},
+  {"company":"富美菊酒造株式会社","city":"富山市", "details":[
+    {"name":"富美菊","kana_name":"ふみぎく"},
+    {"name":"羽根屋","kana_name":"はねや"}]},
+  {"company":"吉乃友酒造有限会社","city":"富山市", "details":[
+    {"name":"よしのとも","kana_name":"よしのとも"}]},
+  {"company":"鷹泉酒造株式会社","city":"富山市", "details":[
+    {"name":"鷹泉","kana_name":"たかいずみ"}]},
+  {"company":"福鶴酒造有限会社","city":"富山市", "details":[
+    {"name":"風の盆","kana_name":"かぜのぼん"}]},
+  {"company":"玉旭酒造有限会社","city":"富山市", "details":[
+    {"name":"おわら娘","kana_name":"おわらむすめ"}]},
+  {"company":"林酒造場","city":"朝日町", "details":[
+    {"name":"黒部峡","kana_name":"くろべきょう"}]},
+  {"company":"皇国晴酒造株式会社","city":"黒部市", "details":[
+    {"name":"幻の瀧","kana_name":"まぼろしのたき"}]},
+  {"company":"銀盤酒造株式会社","city":"黒部市", "details":[
+    {"name":"銀盤","kana_name":"ぎんばん"}]},
+  {"company":"本江酒造株式会社","city":"魚津市", "details":[
+    {"name":"北洋","kana_name":"ほくよう"}]},
+  {"company":"宮崎酒造株式会社 ","city":"滑川市", "details":[
+    {"name":"蜃気楼","kana_name":"しんきろう"}]},
+  {"company":"千代鶴酒造合資会社","city":"滑川市", "details":[
+    {"name":"千代鶴","kana_name":"ちよづる"}]},
+  {"company":"有澤酒造店","city":"上市町", "details":[
+    {"name":"白緑","kana_name":"しろみどり"}]},
+  {"company":"高澤酒造場","city":"氷見市", "details":[
+    {"name":"曙","kana_name":"あけぼの"}]},
+  {"company":"有限会社清都酒造場","city":"高岡市", "details":[
+    {"name":"勝駒","kana_name":"かちこま"}]},
+  {"company":"日本晴酒造合資会社","city":"高岡市", "details":[
+    {"name":"日本晴","kana_name":"にほんばれ"}]},
+  {"company":"戸出酒造有限会社","city":"高岡市", "details":[
+    {"name":"勝鬨","kana_name":"かちどき"}]},
+  {"company":"黒田酒造株式会社","city":"小矢部市", "details":[
+    {"name":"北一","kana_name":"きたいち"}]},
+  {"company":"若鶴酒造株式会社","city":"砺波市", "details":[
+    {"name":"若鶴","kana_name":"わかつる"}]},
+  {"company":"吉江酒造株式会社","city":"砺波市", "details":[
+    {"name":"太刀山","kana_name":"たちやま"}]},
+  {"company":"合名会社若駒酒造場","city":"南砺市", "details":[
+    {"name":"若駒","kana_name":"わかこま"}]},
+  {"company":"成政酒造株式会社","city":"南砺市", "details":[
+    {"name":"成政","kana_name":"なりまさ"}]},
+  {"company":"三笑楽酒造株式会社","city":"南砺市", "details":[
+    {"name":"三笑楽","kana_name":"さんしょうらく"}]},
+  {"company":"立山酒造株式会社","city":"砺波市", "details":[
+    {"name":"立山","kana_name":"たてやま"},
+    {"name":"銀嶺立山","kana_name":"ぎんれいたてやま"}]}
+]},
+{"name_n":"石川県","city_r":[
+  {"company":"菊姫","city":"白山市", "details":[
+    {"name":"菊姫","kana_name":"きくひめ"}]},
+  {"company":"車多酒造","city":"白山市", "details":[
+    {"name":"天狗舞","kana_name":"てんぐまい"},
+    {"name":"五凛","kana_name":"ごりん"}]},
+  {"company":"吉田酒造店","city":"白山市", "details":[
+    {"name":"手取川","kana_name":"てどりがわ"}]},
+  {"company":"金谷酒造","city":"白山市", "details":[
+    {"name":"高砂","kana_name":"たかさご"}]},
+  {"company":"小堀酒造店","city":"白山市", "details":[
+    {"name":"萬歳楽","kana_name":"まんざいらく"}]},
+  {"company":"鹿野酒造","city":"加賀市", "details":[
+    {"name":"常きげん","kana_name":"じょうきげん"},
+    {"name":"益荒男","kana_name":"ますらお"}]},
+  {"company":"宮元酒造店","city":"能美市", "details":[
+    {"name":"夢醸","kana_name":"むじょう"}]},
+  {"company":"福光屋","city":"金沢市", "details":[
+    {"name":"福正宗","kana_name":"ふくまさむね"},
+    {"name":"加賀鳶","kana_name":"かがとび"},
+    {"name":"黒帯","kana_name":"くろおび"},
+    {"name":"瑞秀","kana_name":"みずほ"},
+    {"name":"百々登勢","kana_name":"ももとせ"},
+    {"name":"鏡花","kana_name":"きょうか"},
+    {"name":"風よ水よ人よ","kana_name":"かぜよみずよひとよ"}]},
+  {"company":"やちや酒造","city":"金沢市", "details":[
+    {"name":"加賀鶴","kana_name":"かがつる"}]},
+  {"company":"宗玄酒造","city":"珠洲市", "details":[
+    {"name":"宗玄","kana_name":"そうげん"}]},
+  {"company":"櫻田酒造","city":"珠洲市", "details":[
+    {"name":"初櫻","kana_name":"はつざくら"},
+    {"name":"大慶","kana_name":"たいけい"}]},
+  {"company":"松波酒造","city":"能登町", "details":[
+    {"name":"大江山","kana_name":"おおえやま"}]},
+  {"company":"数馬酒造","city":"能登町", "details":[
+    {"name":"竹葉","kana_name":"ちくは"}]},
+  {"company":"鶴野酒造","city":"能登町", "details":[
+    {"name":"谷泉","kana_name":"たにいずみ"}]},
+  {"company":"中野酒造","city":"輪島市", "details":[
+    {"name":"亀泉","kana_name":"かめいずみ"}]},
+  {"company":"鳥屋酒造","city":"中能登町", "details":[
+    {"name":"池月","kana_name":"いけづき"}]},
+  {"company":"農口酒造","city":"能美市", "details":[
+    {"name":"農口","kana_name":"のぐち"}]}
+]},
+{"name_n":"福井県","city_r":[
+  {"company":"西岡河村酒造","city":"福井市", "details":[
+    {"name":"月丸","kana_name":"つきまる"},
+    {"name":"天津神力","kana_name":"あまつしんりき"},
+    {"name":"かたかごの花","kana_name":"かたかごのはな"}]},
+  {"company":"安本酒造","city":"福井市", "details":[
+    {"name":"白岳仙","kana_name":"はくがくせん"}]},
+  {"company":"毛利酒造","city":"福井市", "details":[
+    {"name":"越の桂月","kana_name":"こしのけいげつ"}]},
+  {"company":"舟木酒造","city":"福井市", "details":[
+    {"name":"北の庄","kana_name":"きたのしょう"}]},
+  {"company":"吉田金右衛門商店","city":"福井市", "details":[
+    {"name":"雲の井","kana_name":"くものい"}]},
+  {"company":"越の磯","city":"福井市", "details":[
+    {"name":"越の磯","kana_name":"こしのいそ"}]},
+  {"company":"常山酒造合資会社","city":"福井市", "details":[
+    {"name":"常山","kana_name":"じょうざん"},
+    {"name":"羽二重正宗","kana_name":"はぶたえまさむね"},
+    {"name":"白山芳水","kana_name":"はくさんほうすい"},
+    {"name":"月のしずく香月華","kana_name":"つきのしずくこうげっか"},
+    {"name":"花水仙","kana_name":"はなすいせん"},
+    {"name":"米太郎","kana_name":"こめたろう"},
+    {"name":"夢一献","kana_name":"ゆめいっこん"}]},
+  {"company":"豊酒造","city":"鯖江市", "details":[
+    {"name":"華燭","kana_name":"かしょく"}]},
+  {"company":"加藤吉平商店","city":"鯖江市", "details":[
+    {"name":"梵","kana_name":"ぼん"}]},
+  {"company":"井波酒造","city":"鯖江市", "details":[
+    {"name":"七ツ星","kana_name":"ななつぼし"}]},
+  {"company":"黒龍酒造","city":"吉田郡永平寺町", "details":[
+    {"name":"黒龍","kana_name":"こくりゅう"}]},
+  {"company":"吉田酒造","city":"吉田郡永平寺町", "details":[
+    {"name":"白龍","kana_name":"はくりゅう"}]},
+  {"company":"田邊酒造","city":"吉田郡永平寺町", "details":[
+    {"name":"越前岬","kana_name":"えちぜんみさき"}]},
+  {"company":"武生酒造","city":"越前市", "details":[
+    {"name":"平和春","kana_name":"へいわはる"}]},
+  {"company":"久保田酒造","city":"坂井市", "details":[
+    {"name":"富久駒","kana_name":"ふくこま"},
+    {"name":"一筆啓上","kana_name":"いっぴつけいじょう"},
+    {"name":"鬼作左","kana_name":"おにさくざ"},
+    {"name":"嫁おどし","kana_name":"よめおどし"}]},
+  {"company":"南部酒造","city":"大野市", "details":[
+    {"name":"花垣","kana_name":"はながき"}]},
+  {"company":"宇野酒造場","city":"", "details":[
+    {"name":"一乃谷","kana_name":"いちのたに"}]},
+  {"company":"真名鶴酒造","city":"大野市", "details":[
+    {"name":"真名鶴","kana_name":"まなつる"}]},
+  {"company":"源平酒造","city":"大野市", "details":[
+    {"name":"源平","kana_name":"げんぺい"}]},
+  {"company":"株式会社一本義久保本店","city":"勝山市", "details":[
+    {"name":"一本義","kana_name":"いっぽんぎ"},
+    {"name":"伝心","kana_name":"でんしん"}]},
+  {"company":"敦賀酒造有限会社","city":"敦賀市", "details":[
+    {"name":"福寿杯","kana_name":"ふくじゅはい"}]},
+  {"company":"三宅彦右衛門商店","city":"美浜町", "details":[
+    {"name":"早瀬浦","kana_name":"はやせうら"}]}
+]},
+{"name_n":"山梨県","city_r":[
+  {"company":"明野銘醸","city":"北杜市", "details":[
+    {"name":"開野の里","kana_name":"あけののさと"}]},
+  {"company":"武の井酒造","city":"北杜市", "details":[
+    {"name":"武の井","kana_name":"たけのい"}]},
+  {"company":"谷桜酒造","city":"北杜市", "details":[
+    {"name":"谷桜","kana_name":"たにざくら"}]},
+  {"company":"八巻酒造店","city":"北杜市", "details":[
+    {"name":"甲斐男山","kana_name":"かいおとこやま"}]},
+  {"company":"山梨銘醸","city":"北杜市", "details":[
+    {"name":"七賢","kana_name":"しちけん"}]},
+  {"company":"田辺酒造","city":"甲州市", "details":[
+    {"name":"菊星","kana_name":"きくぼし"}]},
+  {"company":"富士醗酵工業","city":"甲州市", "details":[
+    {"name":"風林火山","kana_name":"ふうりんかざん"}]},
+  {"company":"養老酒造","city":"山梨市", "details":[
+    {"name":"養老","kana_name":"ようろう"}]},
+  {"company":"石川酒造店","city":"甲斐市", "details":[
+    {"name":"登美正宗","kana_name":"とみまさむね"}]},
+  {"company":"太冠酒造","city":"甲府市", "details":[
+    {"name":"太冠","kana_name":"たいかん"}]},
+  {"company":"腕相撲酒造","city":"笛吹市", "details":[
+    {"name":"腕相撲","kana_name":"うでずもう"}]},
+  {"company":"笹一酒造","city":"大月市", "details":[
+    {"name":"笹一","kana_name":"ささいち"}]},
+  {"company":"横内酒造店","city":"南アルプス市", "details":[
+    {"name":"榊正宗","kana_name":"さかきまさむね"}]},
+  {"company":"二葉屋酒造店","city":"西八代郡市川三郷町", "details":[
+    {"name":"栴檀","kana_name":"せんだん"}]},
+  {"company":"大久保酒造本店","city":"南巨摩郡富士川町", "details":[
+    {"name":"梅が枝","kana_name":"うめがえだ"}]},
+  {"company":"萬屋醸造店","city":"南巨摩郡富士川町", "details":[
+    {"name":"春鴬囀","kana_name":"しゅんのうてん"}]},
+  {"company":"井出醸造店","city":"南都留郡富士河口湖町", "details":[
+    {"name":"甲斐の開運","kana_name":"かいのかいうん"}]},
+  {"company":"横山酒造店","city":"南巨摩郡南部町", "details":[
+    {"name":"日の出菊","kana_name":"ひのできく"}]}
+]},
+{"name_n":"長野県","city_r":[
+  {"company":"大塚酒造","city":"小諸市", "details":[
+    {"name":"浅間嶽","kana_name":"あさまだけ"}]},
+  {"company":"黒澤酒造","city":"佐久穂町", "details":[
+    {"name":"井筒長","kana_name":"いづつちょう"}]},
+  {"company":"漆戸醸造","city":"伊那市", "details":[
+    {"name":"伊那部宿","kana_name":"いなべじゅく"},
+    {"name":"井の頭","kana_name":"いのかしら"}]},
+  {"company":"井賀屋酒造店","city":"中野市", "details":[
+    {"name":"石清水","kana_name":"いわしみず"}]},
+  {"company":"岡崎酒造","city":"上田市", "details":[
+    {"name":"上田城","kana_name":"うえだじょう"}]},
+  {"company":"雲山銘醸","city":"長野市", "details":[
+    {"name":"雲山","kana_name":"うんざん"}]},
+  {"company":"坂井銘醸","city":"千曲市", "details":[
+    {"name":"雲山","kana_name":"うんざん"}]},
+  {"company":"玉村本店","city":"下高井郡山ノ内町", "details":[
+    {"name":"縁喜","kana_name":"えんぎ"}]},
+  {"company":"大國酒造","city":"伊那市", "details":[
+    {"name":"大國","kana_name":"おおくに"}]},
+  {"company":"長野銘醸","city":"千曲市", "details":[
+    {"name":"オバステ正宗","kana_name":"おばすてまさむね"}]},
+  {"company":"豊島屋","city":"岡谷市", "details":[
+    {"name":"御柱","kana_name":"おんばしら"}]},
+  {"company":"市野屋商店","city":"大町市", "details":[
+    {"name":"金蘭黒部","kana_name":"きんらんくろべ"}]},
+  {"company":"酒千蔵野","city":"長野市", "details":[
+    {"name":"桂正宗","kana_name":"かつらまさむね"}]},
+  {"company":"今井酒造店","city":"長野市", "details":[
+    {"name":"風の露","kana_name":"かぜのしづく"},
+    {"name":"五岳","kana_name":"ごがく"},
+    {"name":"若緑","kana_name":"わかみどり"}]},
+  {"company":"笑亀酒造","city":"塩尻市", "details":[
+    {"name":"嘉根満","kana_name":"かねまん"},
+    {"name":"からから大王","kana_name":"からからだいおう"},
+    {"name":"からから帝王","kana_name":"からからていおう"}]},
+  {"company":"酒千蔵野","city":"長野市", "details":[
+    {"name":"川中島","kana_name":"かわなかじま"},
+    {"name":"川中島 幻舞","kana_name":"かわなかじま"}]},
+  {"company":"喜久水酒造","city":"飯田市", "details":[
+    {"name":"喜久水","kana_name":"きくすい"}]},
+  {"company":"湯川酒造店","city":"木曽郡木祖村", "details":[
+    {"name":"木曽路","kana_name":"きそじ"}]},
+  {"company":"岡崎酒造","city":"上田市", "details":[
+    {"name":"亀齢","kana_name":"きれい"}]},
+  {"company":"田中屋酒造店","city":"飯山市", "details":[
+    {"name":"金瓢養老","kana_name":"きんぴょうようろう"}]},
+  {"company":"遠藤酒造場","city":"須坂市", "details":[
+    {"name":"渓流","kana_name":"けいりゅう"}]},
+  {"company":"坂井銘醸","city":"千曲市", "details":[
+    {"name":"原酒宝ケ池","kana_name":"げんしゅたからがいけ"}]},
+  {"company":"桝一市村酒造場","city":"上高井郡小布施町", "details":[
+    {"name":"鴻山","kana_name":"こうざん"}]},
+  {"company":"高天酒造","city":"岡谷市", "details":[
+    {"name":"高天","kana_name":"こうてん"}]},
+  {"company":"武重本家酒造","city":"佐久市", "details":[
+    {"name":"米米酒","kana_name":"こめこめしゅ"}]},
+  {"company":"沓掛酒造","city":"上田市", "details":[
+    {"name":"福無量","kana_name":"ふくむりょう"},
+    {"name":"互","kana_name":"ご"},
+    {"name":"郷の舞","kana_name":"さとのまい"},
+    {"name":"鐵の道","kana_name":"てつのみち"},
+    {"name":"真田城","kana_name":"さなだじょう"}]},
+  {"company":"喜久水酒造","city":"飯田市", "details":[
+    {"name":"猿庫の泉","kana_name":"さるくらのいずみ"}]},
+  {"company":"伴野酒造","city":"佐久市", "details":[
+    {"name":"澤の花","kana_name":"さわのはな"},
+    {"name":"Beau Michelle","kana_name":"ボー・ミッシェル"}]},
+  {"company":"宮島酒店","city":"伊那市", "details":[
+    {"name":"信濃錦","kana_name":"しなのにしき"}]},
+  {"company":"大澤酒造","city":"佐久市", "details":[
+    {"name":"信濃のかたりべ","kana_name":"しなののかたりべ"}]},
+  {"company":"武重本家酒造","city":"佐久市", "details":[
+    {"name":"宿場","kana_name":"しゅくば"}]},
+  {"company":"笑亀酒造","city":"塩尻市", "details":[
+    {"name":"笑亀","kana_name":"しょうき"}]},
+  {"company":"明科酒造","city":"安曇野市", "details":[
+    {"name":"常念","kana_name":"じょうねん"}]},
+  {"company":"舞姫","city":"諏訪市", "details":[
+    {"name":"信州舞姫","kana_name":"しんしゅうまいひめ"}]},
+  {"company":"伊東酒造","city":"諏訪市", "details":[
+    {"name":"深水","kana_name":"しんすい"}]},
+  {"company":"EH酒造","city":"安曇野市", "details":[
+    {"name":"酔園","kana_name":"すいえん"}]},
+  {"company":"喜久水酒造","city":"飯田市", "details":[
+    {"name":"翠嶂","kana_name":"すいしょう"}]},
+  {"company":"岡崎酒造","city":"上田市", "details":[
+    {"name":"綏酔","kana_name":"すいすい"}]},
+  {"company":"杉の森酒造","city":"塩尻市", "details":[
+    {"name":"杉の森","kana_name":"すぎのもり"}]},
+  {"company":"桝一市村酒造場","city":"上高井郡小布施町", "details":[
+    {"name":"スクエア・ワン","kana_name":"すくえあ・わん"}]},
+  {"company":"大澤酒造","city":"佐久市", "details":[
+    {"name":"善光寺秘蔵酒","kana_name":"ぜんこうじひぞうしゅ"}]},
+  {"company":"仙醸","city":"伊那市", "details":[
+    {"name":"仙醸","kana_name":"せんじょう"}]},
+  {"company":"大雪渓酒造","city":"北安曇郡池田町", "details":[
+    {"name":"大雪渓","kana_name":"だいせっけい"}]},
+  {"company":"遠藤酒造場","city":"須坂市", "details":[
+    {"name":"大地球","kana_name":"だいちきゅう"}]},
+  {"company":"諏訪大津屋本家酒造","city":"茅野市", "details":[
+    {"name":"ダイヤ菊","kana_name":"だいやぎく"}]},
+  {"company":"丸永酒造場","city":"塩尻市", "details":[
+    {"name":"高波","kana_name":"たかなみ"}]},
+  {"company":"武重本家酒造","city":"佐久市", "details":[
+    {"name":"つゆ草","kana_name":"つゆくさ"}]},
+  {"company":"天法酒造","city":"千曲市", "details":[
+    {"name":"天法","kana_name":"てんぽう"}]},
+  {"company":"高橋助作酒造店","city":"信濃町", "details":[
+    {"name":"戸隠","kana_name":"とがくし"}]},
+  {"company":"中善酒造店","city":"木曽郡木曽町", "details":[
+    {"name":"中乗さん","kana_name":"なかのりさん"}]},
+  {"company":"七笑酒造","city":"木曽郡木曽町", "details":[
+    {"name":"七笑","kana_name":"ななわらい"}]},
+  {"company":"よしのや","city":"長野市", "details":[
+    {"name":"西之門","kana_name":"にしのもん"}]},
+  {"company":"坂井銘醸","city":"千曲市", "details":[
+    {"name":"西之門","kana_name":"にしのもん"}]},
+  {"company":"薄井商店","city":"大町市", "details":[
+    {"name":"白馬錦","kana_name":"はくばにしき"}]},
+  {"company":"桝一市村酒造場","city":"上高井郡小布施町", "details":[
+    {"name":"白金","kana_name":"はっきん"}]},
+  {"company":"武重本家酒造","city":"佐久市", "details":[
+    {"name":"ハートホリデー","kana_name":"はーとほりでー"}]},
+  {"company":"大國酒造","city":"伊那市", "details":[
+    {"name":"氷河","kana_name":"ひょうが"}]},
+  {"company":"明科酒造","city":"安曇野市", "details":[
+    {"name":"広田泉","kana_name":"ひろたいずみ"}]},
+  {"company":"桝一市村酒造場","city":"上高井郡小布施町", "details":[
+    {"name":"碧い軒","kana_name":"へきいけん"}]},
+  {"company":"沓掛酒造","city":"上田市", "details":[
+    {"name":"福無量","kana_name":"ふくむりょう"}]},
+  {"company":"酒千蔵野","city":"長野市", "details":[
+    {"name":"ふわり粋酔","kana_name":"ふわりすいすい"}]},
+  {"company":"武重本家酒造","city":"佐久市", "details":[
+    {"name":"牧水","kana_name":"ぼくすい"}]},
+  {"company":"酒ぬのや本金酒造","city":"諏訪市", "details":[
+    {"name":"本金","kana_name":"ほんきん"}]},
+  {"company":"宮坂醸造","city":"諏訪市", "details":[
+    {"name":"真澄","kana_name":"ますみ"}]},
+  {"company":"高橋助作酒造店","city":"信濃町", "details":[
+    {"name":"松尾","kana_name":"まつお"}]},
+  {"company":"高橋助作酒造店","city":"信濃町", "details":[
+    {"name":"松牡丹","kana_name":"まつぼたん"},
+    {"name":"松乃尾","kana_name":"まつのお"}]},
+  {"company":"武重本家酒造","city":"佐久市", "details":[
+    {"name":"御園竹","kana_name":"みそのたけ"}]},
+  {"company":"田中屋酒造店","city":"飯山市", "details":[
+    {"name":"水尾","kana_name":"みずお"}]},
+  {"company":"大國酒造","city":"伊那市", "details":[
+    {"name":"御馬寄","kana_name":"みまよせ"}]},
+  {"company":"豊島屋","city":"岡谷市", "details":[
+    {"name":"神渡","kana_name":"みわたり"}]},
+  {"company":"大澤酒造","city":"佐久市", "details":[
+    {"name":"明鏡止水","kana_name":"めいきょうしすい"}]},
+  {"company":"伊東酒造","city":"諏訪市", "details":[
+    {"name":"八剣","kana_name":"やつるぎ"}]},
+  {"company":"坂井銘醸","city":"千曲市", "details":[
+    {"name":"夢二","kana_name":"ゆめじ"}]},
+  {"company":"武重本家酒造","city":"佐久市", "details":[
+    {"name":"酔牧水","kana_name":"よいぼくすい"}]},
+  {"company":"遠藤酒造場","city":"須坂市", "details":[
+    {"name":"養老正宗","kana_name":"ようろうまさむね"}]},
+  {"company":"小野酒造店","city":"上伊那郡辰野町", "details":[
+    {"name":"夜明け前","kana_name":"よあけまえ"}]},
+  {"company":"伊東酒造","city":"諏訪市", "details":[
+    {"name":"横笛","kana_name":"よこぶえ"}]},
+  {"company":"武重本家酒造","city":"佐久市", "details":[
+    {"name":"四方の友","kana_name":"よものとも"}]},
+  {"company":"麗人酒造","city":"諏訪市", "details":[
+    {"name":"麗人","kana_name":"れいじん"}]},
+  {"company":"大信州酒造","city":"松本市島立", "details":[
+    {"name":"大信州","kana_name":"だいしんしゅう"},
+    {"name":"信濃薫水","kana_name":"しなのくんすい"},
+    {"name":"春香彩","kana_name":"しゅんこうさい"},
+    {"name":"香月","kana_name":"こうげつ"}]},
+  {"company":"横綱酒造","city":"長野市川中島町", "details":[
+    {"name":"富士横綱","kana_name":"ふじよこづな"},
+    {"name":"鞭聲粛粛","kana_name":"べんせいしゅくしゅく"},
+    {"name":"久之蔵","kana_name":""},
+    {"name":"かるかや","kana_name":""}]}
+]},
+{"name_n":"岐阜県","city_r":[
+  {"company":"中島醸造株式会社","city":"瑞浪市土岐町", "details":[
+    {"name":"小左衛門","kana_name":"こざえもん"},
+    {"name":"始祿","kana_name":"しろく"},
+    {"name":"甘酸っぱいにごり酒","kana_name":"あますっぱいにごりさけ"},
+    {"name":"特別純米信濃美山錦","kana_name":"とくじゅんみやま"},
+    {"name":"純米吟醸備前雄町","kana_name":"じゅんぎんおまち"},
+    {"name":"純米山田錦65","kana_name":"じゅんまいやまだあからべる"},
+    {"name":"純米大吟醸40","kana_name":"じゅんまいだいぎんよんじゅう"}]},
+  {"company":"千代菊","city":"羽島市", "details":[
+    {"name":"千代菊","kana_name":"ちよきく"}]},
+  {"company":"白扇酒造株式会社","city":"加茂郡川辺町", "details":[
+    {"name":"花美蔵","kana_name":"はなみくら"}]},
+  {"company":"御代桜醸造株式会社","city":"美濃加茂市", "details":[
+    {"name":"御代桜","kana_name":"みよざくら"}]},
+  {"company":"菊川株式会社","city":"各務原市", "details":[
+    {"name":"菊川","kana_name":"きくかわ"}]},
+  {"company":"玉泉堂酒造","city":"養老郡養老町", "details":[
+    {"name":"美濃菊","kana_name":"みのぎく"}]},
+  {"company":"大坪酒造店","city":"飛騨市", "details":[
+    {"name":"飛騨娘","kana_name":"ひだむすめ"},
+    {"name":"神代","kana_name":"じんだい"},
+    {"name":"神代上澄","kana_name":"じんだいうわずみ"},
+    {"name":"飛騨の里","kana_name":"ひだのさと"},
+    {"name":"冬ごもり","kana_name":"ふゆごもり"},
+    {"name":"船津","kana_name":"ふなつ"},
+    {"name":"空地音","kana_name":"そらちね"},
+    {"name":"酒心求道","kana_name":"しゅしんきゅうどう"},
+    {"name":"大寒しぼり","kana_name":"だいかんしぼり"},
+    {"name":"高原郷","kana_name":"たかはらごう"}]},
+  {"company":"渡邊酒造店","city":"飛騨市", "details":[
+    {"name":"蓬莱","kana_name":"ほうらい"},
+    {"name":"小町桜","kana_name":"こまちざくら"},
+    {"name":"飛騨之匠","kana_name":"ひだのたくみ"},
+    {"name":"おんざろっく","kana_name":"おんざろっく"},
+    {"name":"とろとろとろ","kana_name":"とろとろとろ"},
+    {"name":"新酒一番にごり","kana_name":"しんしゅいちばんにごり"},
+    {"name":"飛騨守五郎八","kana_name":"ひだのもりごろうはち"},
+    {"name":"飛騨の切り札","kana_name":"ひだのきりふだ"},
+    {"name":"花もも","kana_name":"はなもも"},
+    {"name":"蓬莱不老仙","kana_name":"ほうらいふろうせん"},
+    {"name":"艶夜の夢","kana_name":"あでよのゆめ"},
+    {"name":"星の舟","kana_name":"ほしのふね"},
+    {"name":"超吟しずく","kana_name":"ちょうぎんしずく"},
+    {"name":"秘封蓬莱","kana_name":"ひふうほうらい"},
+    {"name":"渡邊一番酒","kana_name":"わたなべいちばんざけ"},
+    {"name":"久衛","kana_name":"ひさもり"},
+    {"name":"非売品の酒","kana_name":"ひばいひんのさけ"},
+    {"name":"蔵元の隠し酒","kana_name":"くらもとのかくしざけ"}]},
+  {"company":"蒲酒造場","city":"飛騨市", "details":[
+    {"name":"白真弓","kana_name":"しらまゆみ"},
+    {"name":"やんちゃ酒","kana_name":"やんちゃさけ"},
+    {"name":"やんちゃ男酒","kana_name":"やんちゃおとこざけ"},
+    {"name":"飛騨山川","kana_name":"ひださんせん"},
+    {"name":"合掌の郷","kana_name":"がっしょうのさと"},
+    {"name":"飛騨の強者","kana_name":"ひだのつわもの"},
+    {"name":"飛騨の涼風","kana_name":"ひだのりょうふう"},
+    {"name":"はてな","kana_name":"はてな"},
+    {"name":"穂の国","kana_name":"ほのくに"},
+    {"name":"花の国","kana_name":"はなのくに"},
+    {"name":"三百年の胸さわぎ","kana_name":"さんびゃくねんのむねさわぎ"},
+    {"name":"どぶろく祭","kana_name":"どぶろくまつり"},
+    {"name":"じゃんぱん","kana_name":"じゃんぱん"},
+    {"name":"杜氏のお墨付き","kana_name":"とうじのおすみつき"},
+    {"name":"飛騨の燗太郎","kana_name":"ひだのかんたろう"},
+    {"name":"白真弓肥太ヱ門","kana_name":"しらまゆみひだえもん"}]},
+  {"company":"平瀬酒造店","city":"高山市", "details":[
+    {"name":"久寿玉","kana_name":"くすだま"}]},
+  {"company":"二木酒造","city":"高山市", "details":[
+    {"name":"玉乃井","kana_name":"たまのい"},
+    {"name":"いちい","kana_name":"いちい"},
+    {"name":"氷室","kana_name":"ひむろ"},
+    {"name":"秋麗の炎","kana_name":"しゅうれいのほのお"},
+    {"name":"両面宿儺","kana_name":"りょうめんすくな"}]},
+  {"company":"川尻酒造場","city":"高山市", "details":[
+    {"name":"ひだ正宗","kana_name":"ひだまさむね"},
+    {"name":"ひだ山水","kana_name":"ひださんすい"},
+    {"name":"地恵","kana_name":"ちけい"},
+    {"name":"天恩","kana_name":"てんおん"}]},
+  {"company":"舩坂酒造店","city":"高山市", "details":[
+    {"name":"深山菊","kana_name":"みやまぎく"},
+    {"name":"飛騨の甚五郎","kana_name":"ひだのじんごろう"},
+    {"name":"四ツ星","kana_name":"よつぼし"},
+    {"name":"にごり酒白無垢","kana_name":"にごりざけしろむく"},
+    {"name":"夕映え","kana_name":"ゆうばえ"}]},
+  {"company":"平田酒造場","city":"高山市", "details":[
+    {"name":"山乃光","kana_name":"やまのひかり"},
+    {"name":"飛騨の華","kana_name":"ひだのはな"},
+    {"name":"酔翁","kana_name":"すいおう"}]},
+  {"company":"老田酒造店","city":"高山市", "details":[
+    {"name":"飛騨自慢鬼ころし","kana_name":"ひだじまんおにころし"},
+    {"name":"飛騨自慢","kana_name":"ひだじまん"},
+    {"name":"老杉","kana_name":"おいすぎ"},
+    {"name":"飛騨のガオロ","kana_name":"ひだのがおろ"},
+    {"name":"晩熟","kana_name":"おくて"},
+    {"name":"朝顔","kana_name":"あさがお"},
+    {"name":"飛騨高山","kana_name":"ひだたかやま"},
+    {"name":"色","kana_name":"しき"}]},
+  {"company":"原田酒造場","city":"高山市", "details":[
+    {"name":"山車","kana_name":"さんしゃ"},
+    {"name":"花山車","kana_name":"はなさんしゃ"},
+    {"name":"飛騨の吟風","kana_name":"ひだのぎんぷう"}]},
+  {"company":"天領酒造","city":"下呂市", "details":[
+    {"name":"飛切り","kana_name":"とびきり"},
+    {"name":"天領","kana_name":"てんりょう"},
+    {"name":"吟","kana_name":"ぎん"},
+    {"name":"天のしずく","kana_name":"てんのしずく"},
+    {"name":"天禄拝領","kana_name":"てんろくはいりょう"},
+    {"name":"杜氏の持ち帰り酒","kana_name":"とうじのもちかえりざけ"}]},
+  {"company":"高木酒造","city":"下呂市", "details":[
+    {"name":"奥飛騨","kana_name":"おくひだ"}]},
+  {"company":"三輪酒造","city":"大垣市船町", "details":[
+    {"name":"白川郷","kana_name":"しらかわごう"},
+    {"name":"道三","kana_name":"どうさん"},
+    {"name":"男爵鉄心","kana_name":"ばろんてっしん"}]}
+]},
+{"name_n":"静岡県","city_r":[
+  {"company":"山中酒造","city":"掛川市", "details":[
+    {"name":"葵天下","kana_name":"あおいてんか"}]},
+  {"company":"磯自慢酒造","city":"焼津市", "details":[
+    {"name":"磯自慢","kana_name":"いそじまん"}]},
+  {"company":"英君酒造","city":"静岡市清水区", "details":[
+    {"name":"英君","kana_name":"えいくん"}]},
+  {"company":"土井酒造場","city":"掛川市", "details":[
+    {"name":"開運","kana_name":"かいうん"},
+    {"name":"遠州灘","kana_name":"えんしゅうなだ"},
+    {"name":"伝 波瀬正吉","kana_name":"でん はせしょうきち"}]},
+  {"company":"三和酒造","city":"静岡市清水区", "details":[
+    {"name":"臥龍梅","kana_name":"がりゅうばい"},
+    {"name":"静ごころ","kana_name":"しずごころ"},
+    {"name":"羽衣の舞","kana_name":""}]},
+  {"company":"青島酒造","city":"藤枝市", "details":[
+    {"name":"喜久酔","kana_name":"きくよい"}]},
+  {"company":"根上酒造店","city":"御殿場市", "details":[
+    {"name":"金明","kana_name":"きんめい"}]},
+  {"company":"君盃酒造","city":"静岡市駿河区", "details":[
+    {"name":"君盃","kana_name":"くんぱい"}]},
+  {"company":"國香酒造","city":"袋井市", "details":[
+    {"name":"國香","kana_name":"こくこう"},
+    {"name":"森の石松","kana_name":"もりのいしまつ"}]},
+  {"company":"森本酒造","city":"菊川市", "details":[
+    {"name":"小夜衣","kana_name":"さよごろも"}]},
+  {"company":"志太泉酒造","city":"藤枝市", "details":[
+    {"name":"志太泉","kana_name":"しだいずみ"},
+    {"name":"にゃんかっぷ","kana_name":"にゃんかっぷ"}]},
+  {"company":"浜松酒造","city":"浜松市中区", "details":[
+    {"name":"出世城","kana_name":"しゅっせじょう"},
+    {"name":"葵御紋","kana_name":"あおいごもん"}]},
+  {"company":"神沢川酒造場","city":"静岡市清水区", "details":[
+    {"name":"正雪","kana_name":"しょうせつ"}]},
+  {"company":"牧野酒造","city":"富士宮市", "details":[
+    {"name":"白糸","kana_name":"しらいと"}]},
+  {"company":"杉井酒造","city":"藤枝市", "details":[
+    {"name":"杉錦","kana_name":"すぎにしき"}]},
+  {"company":"千寿酒造","city":"磐田市", "details":[
+    {"name":"千寿白拍子","kana_name":"せんじゅしらびょうし"},
+    {"name":"誉関","kana_name":"ほまれぜき"}]},
+  {"company":"富士高砂酒造","city":"富士宮市", "details":[
+    {"name":"高砂","kana_name":"たかさご"}]},
+  {"company":"駿河酒造場","city":"静岡市駿河区", "details":[
+    {"name":"忠正","kana_name":"ちゅうまさ"},
+    {"name":"安倍街道","kana_name":"あべかいどう"},
+    {"name":"海舟の山廃","kana_name":"かいしゅうのやまはい"}]},
+  {"company":"駿河酒造場","city":"静岡市駿河区", "details":[
+    {"name":"天虹","kana_name":"てんこう"},
+    {"name":"萩の蔵","kana_name":"はぎのくら"},
+    {"name":"曾我鶴","kana_name":"そがつる"}]},
+  {"company":"萩錦酒造","city":"静岡市駿河区", "details":[
+    {"name":"萩錦","kana_name":"はぎにしき"}]},
+  {"company":"初亀醸造","city":"藤枝市", "details":[
+    {"name":"初亀","kana_name":"はつかめ"}]},
+  {"company":"高嶋酒造","city":"沼津市", "details":[
+    {"name":"白隠正宗","kana_name":"はくいんまさむね"}]},
+  {"company":"花の舞酒造","city":"浜松市浜北区", "details":[
+    {"name":"花の舞","kana_name":"はなのまい"}]},
+  {"company":"万大醸造","city":"伊豆市", "details":[
+    {"name":"萬燿","kana_name":"ばんよう"},
+    {"name":"脇田屋","kana_name":"わきたや"},
+    {"name":"坦庵","kana_name":"たんあん"}]},
+  {"company":"富士錦酒造","city":"富士宮市", "details":[
+    {"name":"富士錦","kana_name":"ふじにしき"},
+    {"name":"白寿","kana_name":"はくじゅ"}]},
+  {"company":"富士正酒造","city":"富士宮市", "details":[
+    {"name":"富士正","kana_name":"ふじまさ"},
+    {"name":"千代乃峯","kana_name":"ちよのみね"}]},
+  {"company":"大村屋酒造場","city":"島田市", "details":[
+    {"name":"若竹","kana_name":"わかたけ"},
+    {"name":"おんな泣かせ","kana_name":"おんななかせ"}]}
+]},
+{"name_n":"愛知県","city_r":[
+  {"company":"神杉酒造","city":"安城市", "details":[
+    {"name":"神杉","kana_name":"かみすぎ"},
+    {"name":"御室櫻","kana_name":"おむろざくら"},
+    {"name":"敷嶋","kana_name":"しきしま"}]},
+  {"company":"萬乗醸造","city":"名古屋市", "details":[
+    {"name":"醸し人九平次","kana_name":"かもしびとくへいじ"},
+    {"name":"萬乗","kana_name":"ばんじょう"},
+    {"name":"酒望子","kana_name":"さかぼうし"}]},
+  {"company":"山忠本家酒造","city":"名古屋市", "details":[
+    {"name":"義侠","kana_name":"ぎきょう"}]},
+  {"company":"清洲桜醸造","city":"清須市", "details":[
+    {"name":"清洲桜","kana_name":"きよすざくら"},
+    {"name":"楽園","kana_name":"らくえん"},
+    {"name":"清洲城信長鬼ころし","kana_name":"きよすじょうのぶながおにころし"},
+    {"name":"花夢里","kana_name":"かむり"}]},
+  {"company":"盛田","city":"名古屋市 醸造は常滑市", "details":[
+    {"name":"ねのひ","kana_name":"ねのひ"},
+    {"name":"子乃日松","kana_name":"ねのひまつ"}]},
+  {"company":"関谷醸造","city":"北設楽郡設楽町", "details":[
+    {"name":"蓬莱泉","kana_name":"ほうらいせん"},
+    {"name":"明眸","kana_name":"めいぼう"}]},
+  {"company":"甘強酒造","city":"海部郡蟹江町", "details":[
+    {"name":"四天王","kana_name":"してんのう"},
+    {"name":"名古屋正宗","kana_name":"なごやまさむね"},
+    {"name":"悪太郎","kana_name":"あくたろう"}]},
+  {"company":"中埜酒造","city":"半田市", "details":[
+    {"name":"國盛","kana_name":"くにざかり"}]},
+  {"company":"盛田金しゃち酒造","city":"半田市", "details":[
+    {"name":"初夢桜","kana_name":"はつゆめざくら"},
+    {"name":"清正","kana_name":"きよまさ"},
+    {"name":"白楽天","kana_name":"はくらくてん"}]},
+  {"company":"澤田酒造","city":"常滑市", "details":[
+    {"name":"白老","kana_name":"はくろう"}]},
+  {"company":"相生ユニビオ","city":"西尾市", "details":[
+    {"name":"あいおい","kana_name":"あいおい"},
+    {"name":"相生乃松","kana_name":"あいおいのまつ"}]},
+  {"company":"柴田酒造場","city":"岡崎市", "details":[
+    {"name":"孝の司","kana_name":"こうのつかさ"}]},
+  {"company":"森山酒造場","city":"北設楽郡東栄町", "details":[
+    {"name":"蜂龍盃","kana_name":"はちりゅうはい"}]},
+  {"company":"日野屋商店","city":"新城市", "details":[
+    {"name":"朝日嶽","kana_name":"あさひだけ"}]},
+  {"company":"福井酒造","city":"豊橋市", "details":[
+    {"name":"四海王","kana_name":"しかいおう"}]},
+  {"company":"伊勢屋商店","city":"豊橋市", "details":[
+    {"name":"公楽","kana_name":"こうらく"}]},
+  {"company":"竹内酒造","city":"蒲郡市", "details":[
+    {"name":"養神","kana_name":"ようじん"}]},
+  {"company":"山崎","city":"西尾市", "details":[
+    {"name":"尊皇","kana_name":"そんのう"},
+    {"name":"尊王","kana_name":"そんのう"}]},
+  {"company":"丸石醸造","city":"岡崎市", "details":[
+    {"name":"長譽","kana_name":"ちょうよ"},
+    {"name":"三河武士","kana_name":"みかわぶし"}]},
+  {"company":"豊田酒造","city":"豊田市", "details":[
+    {"name":"智恵泉","kana_name":"ちえいず"}]},
+  {"company":"浦野","city":"豊田市", "details":[
+    {"name":"菊石","kana_name":"きくいし"}]},
+  {"company":"中垣酒造","city":"豊田市", "details":[
+    {"name":"賜冠","kana_name":"しかん"}]},
+  {"company":"永井酒造場","city":"碧南市", "details":[
+    {"name":"昇勢","kana_name":"しょうせい"}]},
+  {"company":"丸一酒造","city":"知多郡阿久比町", "details":[
+    {"name":"冠勲","kana_name":"かんくん"}]},
+  {"company":"野村酒造","city":"知多郡東浦町", "details":[
+    {"name":"幸娘","kana_name":"さちむすめ"}]},
+  {"company":"原田酒造","city":"知多郡東浦町", "details":[
+    {"name":"生道井","kana_name":"いくじい"}]},
+  {"company":"山盛酒造","city":"名古屋市", "details":[
+    {"name":"鷹の夢","kana_name":"たかのゆめ"}]},
+  {"company":"神の井酒造","city":"名古屋市", "details":[
+    {"name":"神の井","kana_name":"かみのい"}]},
+  {"company":"金虎酒造","city":"名古屋市", "details":[
+    {"name":"金虎","kana_name":"きんとら"}]},
+  {"company":"東春酒造","city":"名古屋市", "details":[
+    {"name":"東龍","kana_name":"あずまりゅう"}]},
+  {"company":"白龍酒造","city":"名古屋市", "details":[
+    {"name":"白龍","kana_name":"はくりゅう"}]},
+  {"company":"八束穂酒造","city":"名古屋市", "details":[
+    {"name":"八束穂","kana_name":"やつかほ"}]},
+  {"company":"常盤醸造","city":"名古屋市", "details":[
+    {"name":"常盤","kana_name":"ときわ"}]},
+  {"company":"糀富","city":"名古屋市", "details":[
+    {"name":"白光山","kana_name":"びゃっこうさん"}]},
+  {"company":"小弓鶴酒造","city":"犬山市", "details":[
+    {"name":"小弓鶴","kana_name":"こゆみつる"}]},
+  {"company":"東洋自慢酒造","city":"犬山市", "details":[
+    {"name":"東洋自慢","kana_name":"とうようじまん"}]},
+  {"company":"丸井酒造","city":"江南市", "details":[
+    {"name":"楽之世","kana_name":"らくのよ"}]},
+  {"company":"山星酒造","city":"江南市", "details":[
+    {"name":"星盛","kana_name":"ほしざかり"}]},
+  {"company":"勲碧酒造","city":"江南市", "details":[
+    {"name":"勲碧","kana_name":"くんぺき"}]},
+  {"company":"東海醗酵工業","city":"北名古屋市", "details":[
+    {"name":"四君子","kana_name":"しくんし"}]},
+  {"company":"山田酒造","city":"海部郡蟹江町", "details":[
+    {"name":"酔泉正宗","kana_name":"すいせんまさむね"}]},
+  {"company":"鶴見酒造","city":"津島市", "details":[
+    {"name":"神鶴","kana_name":"かみつる"}]},
+  {"company":"長珍酒造","city":"津島市", "details":[
+    {"name":"長珍","kana_name":"ちょうちん"}]},
+  {"company":"山忠新家","city":"愛西市", "details":[
+    {"name":"雲井","kana_name":"くもい"}]},
+  {"company":"青木酒造","city":"愛西市", "details":[
+    {"name":"米宗","kana_name":"こめそう"},
+    {"name":"やまはい","kana_name":"やまはい"},
+    {"name":"やまはいほまれ","kana_name":"やまはいほまれ"}]},
+  {"company":"水谷酒造","city":"愛西市", "details":[
+    {"name":"千瓢","kana_name":"せんぴょう"}]},
+  {"company":"内藤醸造","city":"稲沢市", "details":[
+    {"name":"木曽三川","kana_name":"きそさんせん"},
+    {"name":"中京美人","kana_name":"ちゅうきょうびじん"}]},
+  {"company":"藤市酒造","city":"稲沢市", "details":[
+    {"name":"ことぶき","kana_name":"ことぶき"}]},
+  {"company":"金銀花酒造","city":"一宮市", "details":[
+    {"name":"金銀花","kana_name":"きんぎんか"}]}
+]},
+{"name_n":"三重県","city_r":[
+  {"company":"大田酒造","city":"伊賀市上之庄", "details":[
+    {"name":"半蔵","kana_name":"はんぞう"}]},
+  {"company":"中井酒造場","city":"伊賀市上野西大手町", "details":[
+    {"name":"三重錦","kana_name":"みえにしき"}]},
+  {"company":"若戎酒造","city":"伊賀市", "details":[
+    {"name":"若戎","kana_name":"わかえびす"}]},
+  {"company":"森喜酒造場","city":"伊賀市", "details":[
+    {"name":"妙の華","kana_name":"たえのはな"}]},
+  {"company":"森本酒造 上野酒造場","city":"伊賀市上野福居町", "details":[
+    {"name":"黒松翁","kana_name":"くろまつおきな"},
+    {"name":"仙右衛門","kana_name":"せんえもん"}]},
+  {"company":"神楽酒造","city":"四日市市", "details":[
+    {"name":"神楽","kana_name":"かぐら"}]},
+  {"company":"石川酒造","city":"四日市市", "details":[
+    {"name":"噴井","kana_name":"ふきい"}]},
+  {"company":"伊藤酒造","city":"四日市市", "details":[
+    {"name":"鈿女","kana_name":"うづめ"}]},
+  {"company":"笹野酒造部","city":"四日市市", "details":[
+    {"name":"白梅","kana_name":"しらうめ"}]},
+  {"company":"丸彦酒造","city":"四日市市", "details":[
+    {"name":"三重の寒梅","kana_name":"みえのかんばい"}]},
+  {"company":"宮崎本店","city":"四日市市", "details":[
+    {"name":"宮の雪","kana_name":"みやのゆき"}]},
+  {"company":"齋木酒造","city":"四日市市", "details":[
+    {"name":"栄光冠","kana_name":"えいこうかん"}]},
+  {"company":"タカハシ酒造","city":"四日市市", "details":[
+    {"name":"伊勢","kana_name":"いせ"}]},
+  {"company":"清水酒造","city":"鈴鹿市", "details":[
+    {"name":"鈴鹿川","kana_name":"すずかがわ"}]},
+  {"company":"早川酒造","city":"三重郡菰野町", "details":[
+    {"name":"早春","kana_name":"そうしゅん"}]},
+  {"company":"稲垣酒造場","city":"三重郡朝日町", "details":[
+    {"name":"御山杉","kana_name":"みやますぎ"}]},
+  {"company":"安達本家酒造","city":"三重郡朝日町", "details":[
+    {"name":"富士の光","kana_name":"ふじのひかり"}]},
+  {"company":"寒紅梅酒造","city":"津市", "details":[
+    {"name":"寒紅梅","kana_name":"かんこうばい"}]},
+  {"company":"小川本家","city":"津市", "details":[
+    {"name":"八千代","kana_name":"やちよ"}]},
+  {"company":"油正","city":"津市", "details":[
+    {"name":"初日","kana_name":"はつひ"}]},
+  {"company":"今村酒造","city":"津市", "details":[
+    {"name":"きげんよし","kana_name":"きげんよし"}]},
+  {"company":"細川酒造","city":"桑名市", "details":[
+    {"name":"上げ馬","kana_name":"あげうま"}]},
+  {"company":"後藤酒造場","city":"桑名市", "details":[
+    {"name":"青雲","kana_name":"せいうん"},
+    {"name":"久波奈","kana_name":"くわな"}]},
+  {"company":"瀧自慢酒造","city":"名張市", "details":[
+    {"name":"瀧自慢","kana_name":"たきじまん"}]},
+  {"company":"木屋正酒造","city":"名張市", "details":[
+    {"name":"高砂","kana_name":"たかさご"}]},
+  {"company":"河武醸造","city":"多気郡多気町", "details":[
+    {"name":"鉾杉","kana_name":"ほこすぎ"}]}
+]},
+{"name_n":"滋賀県","city_r":[
+  {"company":"池本酒造","city":"高島市", "details":[
+    {"name":"琵琶の長寿","kana_name":"びわのちょうじゅ"}]},
+  {"company":"上原酒造","city":"高島市", "details":[
+    {"name":"奥琵琶湖","kana_name":"おくびわこ"},
+    {"name":"亀亀覇","kana_name":"かめかめは"},
+    {"name":"クレオパトラの忘れ物","kana_name":"くれおぱとらのわすれもの"},
+    {"name":"不老泉","kana_name":"ふろうせん"}]},
+  {"company":"北島酒造","city":"湖南市", "details":[
+    {"name":"御代榮","kana_name":"みよさかえ"},
+    {"name":"大吟生もと","kana_name":"だいぎんきもと"}]},
+  {"company":"平井商店","city":"大津市", "details":[
+    {"name":"浅茅生","kana_name":"あさじう"}]},
+  {"company":"喜多酒造","city":"東近江市", "details":[
+    {"name":"喜楽長","kana_name":"きらくちょう"},
+    {"name":"天保正一","kana_name":"てんぽしょういち"}]},
+  {"company":"畑酒造","city":"東近江市", "details":[
+    {"name":"喜量能","kana_name":"きりょうよし"},
+    {"name":"大治郎","kana_name":"だいじろう"}]},
+  {"company":"近江酒造","city":"東近江市", "details":[
+    {"name":"志賀盛","kana_name":"しがさかり"},
+    {"name":"しがさくら","kana_name":"しがさくら"}]},
+  {"company":"松瀬酒造","city":"蒲生郡竜王町", "details":[
+    {"name":"松の司","kana_name":"まつのつかさ"}]},
+  {"company":"冨田酒造","city":"長浜市", "details":[
+    {"name":"七本鎗","kana_name":"しちほんやり"}]},
+  {"company":"岡村本家","city":"犬上郡豊郷町", "details":[
+    {"name":"金亀","kana_name":"きんかめ"}]},
+  {"company":"太田酒造","city":"草津市", "details":[
+    {"name":"道灌","kana_name":"どうかん"}]}
+]},
+{"name_n":"京都府","city_r":[
+  {"company":"齊藤酒造","city":"京都市伏見区", "details":[
+    {"name":"英勲","kana_name":"えいくん"},
+    {"name":"井筒屋伊兵衛","kana_name":"いづつやいへえ"},
+    {"name":"大鷹","kana_name":"おおたか"},
+    {"name":"一吟","kana_name":"いちぎん"},
+    {"name":"もろみ音","kana_name":"もろみね"},
+    {"name":"古都千年","kana_name":"ことせんねん"}]},
+  {"company":"黄桜","city":"京都市伏見区", "details":[
+    {"name":"黄桜","kana_name":"きざくら"}]},
+  {"company":"キンシ正宗","city":"京都市伏見区", "details":[
+    {"name":"キンシ正宗","kana_name":"きんしまさむね"}]},
+  {"company":"月桂冠","city":"京都市伏見区", "details":[
+    {"name":"月桂冠","kana_name":"げっけいかん"},
+    {"name":"笠置屋","kana_name":"かさぎや"}]},
+  {"company":"宝酒造","city":"京都市伏見区", "details":[
+    {"name":"松竹梅","kana_name":"しょうちくばい"}]},
+  {"company":"招徳酒造","city":"京都市伏見区", "details":[
+    {"name":"招徳","kana_name":"しょうとく"},
+    {"name":"花洛","kana_name":"からく"},
+    {"name":"延寿","kana_name":"えんじゅ"}]},
+  {"company":"玉乃光酒造","city":"京都市伏見区", "details":[
+    {"name":"玉乃光","kana_name":"たまのひかり"}]},
+  {"company":"増田徳兵衛商店","city":"京都市伏見区", "details":[
+    {"name":"月の桂","kana_name":"つきのかつら"}]},
+  {"company":"北川本家","city":"京都市伏見区", "details":[
+    {"name":"富翁","kana_name":"とみおう"}]},
+  {"company":"藤岡酒造","city":"京都市伏見区", "details":[
+    {"name":"蒼空","kana_name":"そうくう"},
+    {"name":"万長","kana_name":"まんちょう"},
+    {"name":"チョロギ酒","kana_name":"ちょろぎしゅ"}]},
+  {"company":"松本酒造","city":"京都市伏見区", "details":[
+    {"name":"桃の滴","kana_name":"もものしずく"},
+    {"name":"日出盛","kana_name":"ひのでさかり"}]},
+  {"company":"向島酒造","city":"京都市伏見区", "details":[
+    {"name":"ふり袖","kana_name":"ふりそで"}]},
+  {"company":"山本本家","city":"京都市伏見区", "details":[
+    {"name":"神聖","kana_name":"しんせい"},
+    {"name":"名誉冠","kana_name":"めいよかん"},
+    {"name":"明けごころ","kana_name":"あけごころ"}]},
+  {"company":"松井酒造","city":"京都市左京区", "details":[
+    {"name":"富士千歳","kana_name":"ふじちとせ"},
+    {"name":"京千歳","kana_name":"きょうちとせ"},
+    {"name":"金瓢","kana_name":"きんぴょう"}]},
+  {"company":"佐々木酒造","city":"京都市上京区", "details":[
+    {"name":"聚楽第","kana_name":"じゅらくだい"}]},
+  {"company":"池田酒造","city":"舞鶴市", "details":[
+    {"name":"池雲","kana_name":"いけくも"}]},
+  {"company":"大石酒造","city":"亀岡市", "details":[
+    {"name":"翁鶴","kana_name":"おきなづる"}]},
+  {"company":"丹山酒造","city":"亀岡市", "details":[
+    {"name":"渚","kana_name":"なぎさ"}]},
+  {"company":"ハクレイ酒造","city":"宮津市", "details":[
+    {"name":"酒呑童子","kana_name":"しゅてんどうじ"}]},
+  {"company":"向井酒造","city":"与謝郡伊根町", "details":[
+    {"name":"京の春","kana_name":"きょうのはる"},
+    {"name":"竹の露","kana_name":"たけのつゆ"},
+    {"name":"ええにょぼ","kana_name":"ええにょぼ"},
+    {"name":"伊根満開","kana_name":"いねまんかい"},
+    {"name":"伏見","kana_name":"ふしみ"}]}
+]},
+{"name_n":"大阪府","city_r":[
+  {"company":"呉春株式会社","city":"池田市綾羽", "details":[
+    {"name":"呉春","kana_name":"ごしゅん"},
+    {"name":"秋鹿","kana_name":"あきしか"},
+    {"name":"奥鹿","kana_name":"おくしか"}]},
+  {"company":"寿酒造","city":"高槻市富田", "details":[
+    {"name":"あやめさけ","kana_name":"あやめさけ"},
+    {"name":"とんださけ","kana_name":"とんださけ"},
+    {"name":"國乃長","kana_name":"くにのちょう"}]},
+  {"company":"山野酒造","city":"交野市私部", "details":[
+    {"name":"片野桜","kana_name":"かたのざくら"}]},
+  {"company":"大門酒造","city":"交野市森南", "details":[
+    {"name":"菊養老","kana_name":"きくようろう"},
+    {"name":"利休梅","kana_name":"りきゅうばい"},
+    {"name":"酒半","kana_name":"りきゅうばい"}]},
+  {"company":"藤本酒造醸","city":"藤井寺市藤井寺", "details":[
+    {"name":"松花鶴","kana_name":"しょうかづる"},
+    {"name":"冨士正","kana_name":"ふじまさ"}]},
+  {"company":"北庄司酒造店","city":"泉佐野市日根野", "details":[
+    {"name":"荘の郷","kana_name":"しょうのさと"},
+    {"name":"都娘","kana_name":"みやこむすめ"},
+    {"name":"泉州路","kana_name":"せんしゅうじ"},
+    {"name":"永代蔵 ","kana_name":"えいたいぐら"}]},
+  {"company":"浪花酒造","city":"阪南市尾崎町", "details":[
+    {"name":"浪花正宗","kana_name":"なにわまさむね"}]},
+  {"company":"西條合資会社","city":"河内長野市長野町", "details":[
+    {"name":"天野酒 ","kana_name":"あまのざけ"}]}
+]},
+{"name_n":"兵庫県","city_r":[
+  {"company":"菊正宗酒造株式会社","city":"神戸市東灘区", "details":[
+    {"name":"菊正宗","kana_name":"きくまさむね"}]},
+  {"company":"剣菱酒造","city":"神戸市東灘区", "details":[
+    {"name":"剣菱","kana_name":"けんびし"}]},
+  {"company":"櫻正宗株式会社","city":"神戸市東灘区", "details":[
+    {"name":"櫻正宗","kana_name":"さくらまさむね"},
+    {"name":"瀧鯉","kana_name":"たきのこい"}]},
+  {"company":"沢の鶴株式会社","city":"神戸市灘区", "details":[
+    {"name":"澤之鶴","kana_name":"さわのつる"}]},
+  {"company":"白鶴酒造","city":"神戸市東灘区", "details":[
+    {"name":"白鶴","kana_name":"はくつる"}]},
+  {"company":"富久娘酒造","city":"神戸市東灘区", "details":[
+    {"name":"富久娘","kana_name":"ふくむすめ"}]},
+  {"company":"合同酒精","city":"神戸市東灘区", "details":[
+    {"name":"富貴","kana_name":"ふうき"}]},
+  {"company":"泉酒造","city":"神戸市", "details":[
+    {"name":"泉正宗","kana_name":"いずみまさむね"}]},
+  {"company":"日本盛株式会社","city":"西宮市", "details":[
+    {"name":"日本盛","kana_name":"にほんさかり"}]},
+  {"company":"白鷹株式会社","city":"西宮市", "details":[
+    {"name":"白鷹","kana_name":"はくたか"}]},
+  {"company":"大関株式会社","city":"西宮市", "details":[
+    {"name":"大関","kana_name":"おおぜき"},
+    {"name":"多聞","kana_name":"たもん"}]},
+  {"company":"辰馬本家酒造","city":"西宮市", "details":[
+    {"name":"白鹿","kana_name":"はくしか"}]},
+  {"company":"小西酒造","city":"伊丹市", "details":[
+    {"name":"白雪","kana_name":"しらゆき"}]},
+  {"company":"香住鶴株式会社","city":"美方郡香美町", "details":[
+    {"name":"香住鶴","kana_name":"かすみつる"}]},
+  {"company":"江井ヶ嶋酒造株式会社","city":"明石市", "details":[
+    {"name":"神鷹","kana_name":"かみたか"}]},
+  {"company":"灘菊酒造株式会社","city":"姫路市", "details":[
+    {"name":"灘菊","kana_name":"なだぎく"}]},
+  {"company":"下村酒造店","city":"姫路市", "details":[
+    {"name":"奥播磨","kana_name":"おくはりま"}]},
+  {"company":"井澤本家","city":"加古郡稲美町", "details":[
+    {"name":"倭小槌","kana_name":"やまとこづち"}]},
+  {"company":"キング醸造","city":"加古郡稲美町", "details":[
+    {"name":"金露","kana_name":"きんろ"}]},
+  {"company":"吉村酒造","city":"美方郡新温泉町", "details":[
+    {"name":"太白","kana_name":"たいはく"}]},
+  {"company":"此の友酒造","city":"朝来市", "details":[
+    {"name":"但馬","kana_name":"たじま"}]},
+  {"company":"田治米合名会社","city":"朝来市", "details":[
+    {"name":"竹泉","kana_name":"ちくせん"}]},
+  {"company":"奥藤商事株式会社、奥藤酒造郷土館","city":"赤穂市", "details":[
+    {"name":"忠臣蔵","kana_name":"ちゅうしんぐら"}]},
+  {"company":"明石酒類醸造株式会社","city":"明石市船上町", "details":[
+    {"name":"明石鯛","kana_name":"あかしたい"}]},
+  {"company":"太陽酒造株式会社","city":"明石市大久保町江井島", "details":[
+    {"name":"赤石","kana_name":"あかし"}]},
+  {"company":"千年一酒造株式会社","city":"淡路市", "details":[
+    {"name":"千年一","kana_name":"せんねんいち"}]},
+  {"company":"都美人酒造株式会社","city":"南あわじ市", "details":[
+    {"name":"都美人","kana_name":"みやこびじん"}]},
+  {"company":"西山酒造 ","city":"丹波市", "details":[
+    {"name":"小鼓","kana_name":"こつづみ"}]},
+  {"company":"神戸酒心館 ","city":"神戸市", "details":[
+    {"name":"福寿","kana_name":"ふくじゅ"}]},
+  {"company":"ヤヱガキ酒造株式会社","city":"姫路市", "details":[
+    {"name":"八重垣","kana_name":"やゑがき"}]},
+  {"company":"富久錦株式会社","city":"加西市", "details":[
+    {"name":"瑞福","kana_name":"ずいふく"},
+    {"name":"神代の舞","kana_name":"かみよのまい"},
+    {"name":"Fu.","kana_name":"ふ"},
+    {"name":"吟霞","kana_name":"ぎんがすみ"},
+    {"name":"春の一刻","kana_name":"はるのいっこく"},
+    {"name":"下天の夢","kana_name":"げてんのゆめ"}]}
+]},
+{"name_n":"奈良県","city_r":[
+  {"company":"今西清兵衛商店","city":"奈良市", "details":[
+    {"name":"春鹿","kana_name":"はるしか"}]},
+  {"company":"奈良豊澤酒造","city":"奈良市", "details":[
+    {"name":"豊祝","kana_name":"ほうしゅく"},
+    {"name":"無上杯","kana_name":"むじょうはい"}]},
+  {"company":"八木酒造","city":"奈良市", "details":[
+    {"name":"升平","kana_name":"しょうへい"}]},
+  {"company":"西田酒造","city":"奈良市", "details":[
+    {"name":"両白","kana_name":"もろはく"}]},
+  {"company":"倉本酒造","city":"奈良市", "details":[
+    {"name":"金嶽","kana_name":"きんがく"},
+    {"name":"つげのひむろ","kana_name":"つげのひむろ"}]},
+  {"company":"安川酒造","city":"奈良市", "details":[
+    {"name":"雪園","kana_name":"ゆきその"}]},
+  {"company":"油長酒造","city":"御所市", "details":[
+    {"name":"風の森","kana_name":"かぜのもり"},
+    {"name":"鷹長","kana_name":"たかちょう"}]},
+  {"company":"葛城酒造","city":"御所市", "details":[
+    {"name":"百楽門","kana_name":"ひゃくらくもん"}]},
+  {"company":"千代酒造","city":"御所市", "details":[
+    {"name":"櫛羅","kana_name":"くじら"},
+    {"name":"篠峯","kana_name":"しのみね"},
+    {"name":"どぶろく","kana_name":"どぶろく"}]},
+  {"company":"梅乃宿酒造","city":"葛城市", "details":[
+    {"name":"梅乃宿","kana_name":"うめのやど"}]},
+  {"company":"上田酒造","city":"生駒市", "details":[
+    {"name":"嬉長","kana_name":"きちょう"}]},
+  {"company":"菊司醸造","city":"生駒市", "details":[
+    {"name":"菊司","kana_name":"きくつかさ"}]},
+  {"company":"中本酒造店","city":"生駒市", "details":[
+    {"name":"山鶴","kana_name":"やまつる"}]},
+  {"company":"稲田酒造","city":"天理市", "details":[
+    {"name":"黒松稲天","kana_name":"くろまついなてん"}]},
+  {"company":"増田酒造","city":"天理市", "details":[
+    {"name":"都姫","kana_name":"みやこひめ"},
+    {"name":"神韻","kana_name":"しんいん"}]},
+  {"company":"中谷酒造","city":"大和郡山市", "details":[
+    {"name":"朝香","kana_name":"あさか"},
+    {"name":"萬穣","kana_name":"ばんじょう"},
+    {"name":"こをろこをろ","kana_name":"こをろこをろ"}]},
+  {"company":"喜多酒造","city":"橿原市", "details":[
+    {"name":"御代菊","kana_name":"みよきく"}]},
+  {"company":"河合酒造","city":"橿原市", "details":[
+    {"name":"出世男","kana_name":"しゅっせおとこ"},
+    {"name":"うねび","kana_name":"うねび"}]},
+  {"company":"金剛力酒造","city":"高市郡高取町", "details":[
+    {"name":"金剛力","kana_name":"こんごうりき"}]},
+  {"company":"喜多酒造","city":"香芝市", "details":[
+    {"name":"歓喜光","kana_name":"かんきこう"}]},
+  {"company":"大倉本家","city":"香芝市", "details":[
+    {"name":"金鼓","kana_name":"きんこ"}]},
+  {"company":"長龍酒造","city":"北葛城郡広陵町", "details":[
+    {"name":"吉野杉の樽酒","kana_name":"よしのすぎのたるざけ"}]},
+  {"company":"山本本家","city":"五條市", "details":[
+    {"name":"松の友","kana_name":"まつのとも"}]},
+  {"company":"五條酒造","city":"五條市", "details":[
+    {"name":"五神","kana_name":"ごしん"}]},
+  {"company":"今西酒造","city":"桜井市", "details":[
+    {"name":"三諸杉","kana_name":"みむろすぎ"}]},
+  {"company":"西内酒造","city":"桜井市", "details":[
+    {"name":"談山","kana_name":"たんざん"}]},
+  {"company":"芳村酒造","city":"宇陀市", "details":[
+    {"name":"千代の松","kana_name":"ちよのまつ"},
+    {"name":"かぎろひ","kana_name":"かぎろひ"}]},
+  {"company":"久保本家酒造","city":"宇陀市", "details":[
+    {"name":"初霞","kana_name":"はつがすみ"}]},
+  {"company":"北村酒造","city":"吉野郡吉野町", "details":[
+    {"name":"猩々","kana_name":"しょうじょう"}]},
+  {"company":"北岡本店","city":"吉野郡吉野町", "details":[
+    {"name":"八咫烏","kana_name":"やたがらす"}]},
+  {"company":"岡本本家","city":"吉野郡大淀町", "details":[
+    {"name":"山桂","kana_name":"やまかつら"}]},
+  {"company":"藤村酒造","city":"吉野郡下市町", "details":[
+    {"name":"万代老松","kana_name":"まんだいおいまつ"}]}
+]},
+{"name_n":"和歌山県","city_r":[
+  {"company":"天長島村酒造","city":"和歌山市本町", "details":[
+    {"name":"天長","kana_name":"てんちょう"},
+    {"name":"高野山","kana_name":""},
+    {"name":"純吟","kana_name":""},
+    {"name":"吉宗","kana_name":""},
+    {"name":"八代将軍 吉宗","kana_name":""},
+    {"name":"熊野路","kana_name":""},
+    {"name":"世界王","kana_name":""},
+    {"name":"美さを菊","kana_name":""},
+    {"name":"天狗","kana_name":""}]},
+  {"company":"吉村秀雄商店","city":"岩出市畑毛", "details":[
+    {"name":"日本城","kana_name":"にほんじょう"},
+    {"name":"亀の歩み","kana_name":"かめのあゆみ"},
+    {"name":"鉄砲隊","kana_name":"てっぽうたい"},
+    {"name":"車坂","kana_name":"くるまざか"}]},
+  {"company":"田端酒造","city":"和歌山市木広町", "details":[
+    {"name":"羅生門","kana_name":"らしょうもん"},
+    {"name":"七人の侍","kana_name":"ななにんのさむらい"},
+    {"name":"大東一","kana_name":"だいとういち"}]},
+  {"company":"世界一統","city":"和歌山市湊紺屋町", "details":[
+    {"name":"イチ","kana_name":"いち"},
+    {"name":"南方","kana_name":""},
+    {"name":"熊楠","kana_name":""},
+    {"name":"米乃滴","kana_name":""},
+    {"name":"いち辛","kana_name":""},
+    {"name":"紀州五十五万石","kana_name":""},
+    {"name":"紀州","kana_name":""},
+    {"name":"世界一統","kana_name":"せかいとういつ"}]},
+  {"company":"祝砲酒造","city":"和歌山市田中町", "details":[
+    {"name":"紀州魁","kana_name":"きしゅうさきがけ"}]},
+  {"company":"名手酒造店","city":"海南市黒江", "details":[
+    {"name":"黒牛","kana_name":"くろうし"},
+    {"name":"一掴","kana_name":"ひとつかみ"},
+    {"name":"野路の菊","kana_name":"のじのきく"},
+    {"name":"紀の国・松の齢","kana_name":"きのくに・まつのよわい"}]},
+  {"company":"中野BC","city":"海南市藤白", "details":[
+    {"name":"紀伊国屋文左衛門","kana_name":"きのくにやぶんざえもん"},
+    {"name":"長久","kana_name":"ちょうきゅう"},
+    {"name":"超超久","kana_name":"ちょうちょうきゅう"}]},
+  {"company":"平和酒造","city":"海南市溝ノ口", "details":[
+    {"name":"紀土-KID-","kana_name":"きど"},
+    {"name":"万葉の和歌鶴","kana_name":""},
+    {"name":"紀美野","kana_name":"きみの"},
+    {"name":"井泉流水 ","kana_name":""}]},
+  {"company":"中尾酒造店","city":"海南市", "details":[
+    {"name":"紀の川","kana_name":""},
+    {"name":"紀州葵紋","kana_name":""},
+    {"name":"帝冠","kana_name":""},
+    {"name":"大峯熊野奥馳道","kana_name":""},
+    {"name":"蟻の熊野詣","kana_name":""},
+    {"name":"くまのみち","kana_name":"くまのみち"},
+    {"name":"伏虎城","kana_name":""},
+    {"name":"奮闘一","kana_name":""},
+    {"name":"宇宙一","kana_name":"うちゅういち"},
+    {"name":"龍王水","kana_name":""},
+    {"name":"こもりの国","kana_name":"こもりのくに"},
+    {"name":"紀の川大鼓","kana_name":""},
+    {"name":"はーとらいんわかやま","kana_name":"はーとらいんわかやま"},
+    {"name":"親不孝道り","kana_name":""},
+    {"name":"いのりのみち","kana_name":"いのりのみち"},
+    {"name":"参詣道","kana_name":""}]},
+  {"company":"平松酒造本家","city":"有田川町下津野", "details":[
+    {"name":"金葵","kana_name":""},
+    {"name":"宗祇誉","kana_name":""}]},
+  {"company":"高垣酒造","city":"有田川町小川", "details":[
+    {"name":"紀勢鶴","kana_name":"きせづる"},
+    {"name":"天久","kana_name":"てんきゅう"},
+    {"name":"紀ノ酒","kana_name":"きのさけ"},
+    {"name":"喜楽里","kana_name":"きらり"},
+    {"name":"龍神丸","kana_name":"りゅうじんまる"},
+    {"name":"流霞","kana_name":"ながれかすみ"},
+    {"name":"にごり酒「白馬」","kana_name":"しらま"},
+    {"name":"月の歌人","kana_name":""},
+    {"name":"純米吟醸生酒「かもすぞ」","kana_name":""}]},
+  {"company":"初光酒造","city":"紀の川市貴志川町丸栖", "details":[
+    {"name":"おめでとう","kana_name":"おめでとう"},
+    {"name":"よろこびの酒","kana_name":"よろこびのさけ"},
+    {"name":"爪剥酒","kana_name":"つまむきのさけ"},
+    {"name":"よろこびの竹 ","kana_name":"よろこびのたけ"},
+    {"name":"歓喜","kana_name":"かんき"},
+    {"name":"寛","kana_name":"くつろぎ"},
+    {"name":"ワールドカップ ","kana_name":"わーるどかっぷ"}]},
+  {"company":"初桜酒造","city":"伊都郡かつらぎ町大字中飯降", "details":[
+    {"name":"高野山聖般若湯","kana_name":""},
+    {"name":"初桜","kana_name":""},
+    {"name":"雑賀","kana_name":"さいか"},
+    {"name":"雑賀の郷","kana_name":"さいかのさと"},
+    {"name":"雑賀孫市","kana_name":"さいかまごいち"},
+    {"name":"雑賀蔵心","kana_name":"さいかぞうしん"},
+    {"name":"雑賀浪漫","kana_name":"さいかろまん"},
+    {"name":"雑賀衆","kana_name":"さいかしゅう"},
+    {"name":"錦郷","kana_name":"にしきのさと"},
+    {"name":"さいかのしずく","kana_name":"さいかのしずく"},
+    {"name":"雑賀梅酒","kana_name":""}]},
+  {"company":"岸野酒造本家","city":"御坊市御坊", "details":[
+    {"name":"紀州美人","kana_name":""}]},
+  {"company":"中勝酒造","city":"田辺市秋津町", "details":[
+    {"name":"弁慶の里","kana_name":""},
+    {"name":"此の友","kana_name":""},
+    {"name":"紀州うめさけ","kana_name":""}]},
+  {"company":"尾崎酒造","city":"新宮市船町", "details":[
+    {"name":"太平洋","kana_name":"たいへいよう"},
+    {"name":"熊野三山","kana_name":"くまのさんざん"},
+    {"name":"熊野紀行","kana_name":""},
+    {"name":"熊野曼荼羅","kana_name":"くまのまんだら"},
+    {"name":"那智の滝","kana_name":"くまのなちのたき"},
+    {"name":"潮岬","kana_name":""},
+    {"name":"方士徐福","kana_name":""},
+    {"name":"ほんまもん","kana_name":"ほんまもん"},
+    {"name":"勇魚 本醸造","kana_name":"いさな"},
+    {"name":"鯨えびす","kana_name":""},
+    {"name":"熊野物語","kana_name":""},
+    {"name":"速玉 特別本醸造生貯蔵酒","kana_name":"はやたま"},
+    {"name":"古座川夜会 特別本醸造酒","kana_name":"くまのがわやかい"},
+    {"name":"熊野旅情","kana_name":""},
+    {"name":"熊野川 本醸造酒","kana_name":"くまのがわ"},
+    {"name":"本宮温泉郷 生貯蔵酒","kana_name":""}]}
+]},
+{"name_n":"鳥取県","city_r":[
+  {"company":"高田酒造場","city":"岩美郡岩美町", "details":[
+    {"name":"瑞泉","kana_name":"ずいせん"}]},
+  {"company":"中川酒造","city":"鳥取市", "details":[
+    {"name":"いなば鶴","kana_name":"いなばづる"},
+    {"name":"いなばの恵み","kana_name":"いなばのめぐみ"},
+    {"name":"福寿海","kana_name":"ふくじゅかい"}]},
+  {"company":"西本酒造場","city":"鳥取市青谷町", "details":[
+    {"name":"笑","kana_name":"えみ"},
+    {"name":"美人長","kana_name":"びじんちょう"}]},
+  {"company":"山根酒造場","city":"鳥取市青谷町", "details":[
+    {"name":"日置桜","kana_name":"ひおきざくら"}]},
+  {"company":"太田酒造場","city":"八頭郡若桜町", "details":[
+    {"name":"氷ノ山","kana_name":"ひょうのせん"},
+    {"name":"辨天娘","kana_name":"べんてんむすめ"}]},
+  {"company":"諏訪酒造","city":"八頭郡智頭町", "details":[
+    {"name":"諏訪泉","kana_name":"すわいずみ"},
+    {"name":"諏訪娘","kana_name":"すわむすめ"}]},
+  {"company":"福羅酒造","city":"東伯郡湯梨浜町", "details":[
+    {"name":"山陰東郷","kana_name":"さんいんとうごう"}]},
+  {"company":"元帥酒造","city":"倉吉市", "details":[
+    {"name":"元帥","kana_name":"げんすい"},
+    {"name":"八賢士","kana_name":"はちけんし"}]},
+  {"company":"高田酒造","city":"倉吉市", "details":[
+    {"name":"此の君","kana_name":"このきみ"},
+    {"name":"此君","kana_name":"しくん"},
+    {"name":"竹葉の露","kana_name":"ちくようのつゆ"},
+    {"name":"ひわだ屋","kana_name":"ひわだや"}]},
+  {"company":"中井酒造","city":"倉吉市", "details":[
+    {"name":"倉よし","kana_name":"くらよし"},
+    {"name":"八潮","kana_name":"やしお"}]},
+  {"company":"藤井酒造","city":"東伯郡三朝町", "details":[
+    {"name":"白狼","kana_name":"はくろう"},
+    {"name":"三朝正宗","kana_name":"みささまさむね"}]},
+  {"company":"梅津酒造","city":"東伯郡北栄町", "details":[
+    {"name":"冨玲","kana_name":"ふれー"}]},
+  {"company":"大谷酒造","city":"東伯郡琴浦町", "details":[
+    {"name":"鷹勇","kana_name":"たかいさみ"}]},
+  {"company":"江原酒造本店","city":"東伯郡琴浦町", "details":[
+    {"name":"伯陽長","kana_name":"はくようちょう"}]},
+  {"company":"久米桜酒造","city":"米子市", "details":[
+    {"name":"久米桜","kana_name":"くめざくら"},
+    {"name":"秀峰大山","kana_name":"しゅうほうだいせん"}]},
+  {"company":"稲田本店","city":"米子市", "details":[
+    {"name":"稲田姫","kana_name":"いなだひめ"},
+    {"name":"トップ水雷","kana_name":"とっぷすいらい"}]},
+  {"company":"大岩酒造本店","city":"日野郡江府町", "details":[
+    {"name":"秀峰岩泉","kana_name":"しゅうほういわいずみ"}]},
+  {"company":"千代むすび酒造","city":"境港市", "details":[
+    {"name":"千代むすび","kana_name":"ちよむすび"},
+    {"name":"長年","kana_name":"ながとし"},
+    {"name":"真壽鏡","kana_name":"ますかがみ"}]}
+]},
+{"name_n":"島根県","city_r":[
+  {"company":"李白酒造","city":"松江市", "details":[
+    {"name":"李白","kana_name":"りはく"}]},
+  {"company":"米田酒造","city":"松江市", "details":[
+    {"name":"豊の秋","kana_name":"とよのあき"},
+    {"name":"トヨノアキ","kana_name":"とよのあき"},
+    {"name":"美保","kana_name":"みほ"},
+    {"name":"春陽","kana_name":"しゅんよう"}]},
+  {"company":"國暉酒造","city":"松江市", "details":[
+    {"name":"國暉","kana_name":"こっき"}]},
+  {"company":"王祿酒造","city":"松江市", "details":[
+    {"name":"王祿","kana_name":"おうろく"}]},
+  {"company":"金鳳酒造","city":"安来市", "details":[
+    {"name":"金鳳","kana_name":"きんぽう"},
+    {"name":"へるん","kana_name":"へるん"}]},
+  {"company":"吉田酒造","city":"安来市", "details":[
+    {"name":"月山","kana_name":"がっさん"},
+    {"name":"智／智則","kana_name":""}]},
+  {"company":"青砥酒造","city":"安来市", "details":[
+    {"name":"ほろ酔","kana_name":"ほろよい"},
+    {"name":"蒼斗七星","kana_name":"あおとしちせい"}]},
+  {"company":"旭日酒造","city":"出雲市", "details":[
+    {"name":"＋旭日","kana_name":"じゅうじあさひ"},
+    {"name":"八千矛","kana_name":"やちほこ"}]},
+  {"company":"板倉酒造","city":"出雲市", "details":[
+    {"name":"天穏","kana_name":"てんおん"}]},
+  {"company":"富士酒造","city":"出雲市", "details":[
+    {"name":"出雲富士","kana_name":"いずもふじ"}]},
+  {"company":"酒持田本店","city":"出雲市", "details":[
+    {"name":"ヤマサン正宗","kana_name":"やまさんまさむね"},
+    {"name":"ヤマサン古滴","kana_name":"やまさんこてき"},
+    {"name":"萌","kana_name":"もえ"}]},
+  {"company":"木次酒造","city":"雲南市", "details":[
+    {"name":"美波太平洋","kana_name":"みなみたいへいよう"},
+    {"name":"翠祥","kana_name":"すいしょう"}]},
+  {"company":"竹下本店","city":"雲南市", "details":[
+    {"name":"出雲誉","kana_name":"いずもほまれ"},
+    {"name":"出雲大衆","kana_name":"いずもたいしゅう"}]},
+  {"company":"赤名酒造","city":"飯南町", "details":[
+    {"name":"絹乃峰","kana_name":"きぬのみね"}]},
+  {"company":"簸上清酒","city":"奥出雲町", "details":[
+    {"name":"簸上正宗","kana_name":"ひかみまさむね"},
+    {"name":"七冠馬","kana_name":"ななかんば"},
+    {"name":"玉鋼","kana_name":"たまはがね"}]},
+  {"company":"奥出雲酒造","city":"奥出雲町", "details":[
+    {"name":"仁多米","kana_name":"にたまい"},
+    {"name":"千壽之泉","kana_name":"せんじゅのいずみ"},
+    {"name":"奥出雲","kana_name":"おくいずも"},
+    {"name":"奥出雲の一滴","kana_name":"おくいずものいってき"}]},
+  {"company":"一宮酒造","city":"大田市", "details":[
+    {"name":"石見銀山","kana_name":"いわみぎんざん"}]},
+  {"company":"木村酒造","city":"大田市", "details":[
+    {"name":"羅浮仙","kana_name":"らふせん"}]},
+  {"company":"若林酒造","city":"温泉津町", "details":[
+    {"name":"開春","kana_name":"かいしゅん"}]},
+  {"company":"加茂福酒造","city":"邑南町", "details":[
+    {"name":"加茂福","kana_name":"かもふく"},
+    {"name":"死神","kana_name":"しにがみ"},
+    {"name":"京太郎","kana_name":"きょうたろう"},
+    {"name":"冠山","kana_name":"かんざん"},
+    {"name":"ワル乃代官","kana_name":"わるのだいかん"}]},
+  {"company":"池月酒造","city":"邑南町", "details":[
+    {"name":"誉池月","kana_name":"ほまれいけづき"}]},
+  {"company":"玉櫻酒造","city":"邑南町", "details":[
+    {"name":"玉櫻","kana_name":"たまざくら"}]},
+  {"company":"日本海酒造","city":"浜田市", "details":[
+    {"name":"環日本海","kana_name":"かんにほんかい"},
+    {"name":"石陽日本海","kana_name":"せきようにほんかい"},
+    {"name":"のど黒","kana_name":"のどぐろ"},
+    {"name":"渦","kana_name":"うず"}]},
+  {"company":"都錦酒造","city":"江津市", "details":[
+    {"name":"都錦","kana_name":"みやこにしき"}]},
+  {"company":"右田本店","city":"益田市本町", "details":[
+    {"name":"宗味","kana_name":"そうみ"}]},
+  {"company":"岡田屋本店","city":"益田市", "details":[
+    {"name":"菊弥栄","kana_name":"きくやさか"}]},
+  {"company":"桑原酒場","city":"益田市中島町", "details":[
+    {"name":"扶桑鶴","kana_name":"ふそうづる"}]},
+  {"company":"華泉酒造","city":"津和野町", "details":[
+    {"name":"華泉","kana_name":"かせん"}]},
+  {"company":"古橋酒造","city":"津和野町", "details":[
+    {"name":"初陣","kana_name":"ういじん"}]},
+  {"company":"財間酒場","city":"津和野町", "details":[
+    {"name":"高砂","kana_name":"たかさご"}]},
+  {"company":"下森酒造場","city":"津和野町", "details":[
+    {"name":"菊露","kana_name":"きくつゆ"}]},
+  {"company":"隠岐酒造","city":"隠岐の島町", "details":[
+    {"name":"隠岐誉","kana_name":"おきほまれ"},
+    {"name":"初桜","kana_name":"はつざくら"},
+    {"name":"御所","kana_name":"ごしょ"},
+    {"name":"菊水","kana_name":"きくすい"},
+    {"name":"沖鶴","kana_name":"おきつる"},
+    {"name":"高正宗","kana_name":"たかまさむね"}]}
+]},
+{"name_n":"岡山県","city_r":[
+  {"company":"嘉美心酒造","city":"浅口市寄島町", "details":[
+    {"name":"嘉美心","kana_name":"かみこころ"},
+    {"name":"嘉美心α 木陰の魚","kana_name":"かみこころあるふぁ こかげのさかな"},
+    {"name":"嘉美心Σ 樹の上の猫","kana_name":"かみこころしぐま きのうえのねこ"},
+    {"name":"大島修一","kana_name":"おおしま しゅういち"},
+    {"name":"長十郎","kana_name":"ちょうじゅうろう"},
+    {"name":"海の道 寄島","kana_name":"うみのみち よりしま"}]},
+  {"company":"平喜酒造","city":"浅口市鴨方町鴨方", "details":[
+    {"name":"喜平","kana_name":"きへい"},
+    {"name":"新婚","kana_name":"しんこん"},
+    {"name":"正義櫻","kana_name":"せいぎざくら"}]},
+  {"company":"ヨイキゲン","city":"総社市", "details":[
+    {"name":"酔機嫌","kana_name":"よいきげん"},
+    {"name":"清音雄町","kana_name":"きよねおまち"},
+    {"name":"雫酒 露","kana_name":"しずくさけ つゆ"},
+    {"name":"碧天","kana_name":"へきてん"}]},
+  {"company":"松永酒造","city":"総社市", "details":[
+    {"name":"かみよ 赤米","kana_name":"かみよ あかまい"},
+    {"name":"常磐鶴","kana_name":"ときわつる"},
+    {"name":"吉備路","kana_name":"きびじ"}]},
+  {"company":"三宅酒造","city":"総社市", "details":[
+    {"name":"粋府","kana_name":"すいふ"},
+    {"name":"媛","kana_name":"ひめ"},
+    {"name":"兄媛","kana_name":"えひめ"}]},
+  {"company":"落酒造場","city":"真庭市", "details":[
+    {"name":"高梁川","kana_name":"たかはしがわ"},
+    {"name":"大正の鶴","kana_name":"たいしょうのつる"}]},
+  {"company":"藤田酒造","city":"浅口市", "details":[
+    {"name":"金光賀真","kana_name":"こんこうかしん"}]},
+  {"company":"丸本酒造","city":"浅口市", "details":[
+    {"name":"賀茂緑","kana_name":"かもみどり"}]},
+  {"company":"垣内酒造","city":"浅口市", "details":[
+    {"name":"若魂","kana_name":"わかたましい"}]},
+  {"company":"神露酒造","city":"浅口市金光町", "details":[
+    {"name":"神露","kana_name":"しんろ"}]},
+  {"company":"磯千鳥酒造","city":"浅口郡里庄町", "details":[
+    {"name":"磯千鳥","kana_name":"いそちどり"}]},
+  {"company":"一鱗酒造本店","city":"倉敷市玉島", "details":[
+    {"name":"一鱗","kana_name":"いちうろこ"}]},
+  {"company":"妹尾酒造本店","city":"倉敷市玉島", "details":[
+    {"name":"瀬戸の恋人","kana_name":"せとのこいびと"}]},
+  {"company":"菊池酒造","city":"倉敷市玉島", "details":[
+    {"name":"燦然","kana_name":"さんぜん"}]},
+  {"company":"不二菊酒造","city":"倉敷市玉島", "details":[
+    {"name":"不二菊","kana_name":"ふじぎく"}]},
+  {"company":"酔宝酒造","city":"倉敷市玉島", "details":[
+    {"name":"酔宝","kana_name":"すいほう"}]},
+  {"company":"渡辺酒造本店","city":"倉敷市水島連島町", "details":[
+    {"name":"嶺乃誉","kana_name":"みねのほまれ"}]},
+  {"company":"遠藤酒造場","city":"倉敷市水島連島町", "details":[
+    {"name":"宝富士","kana_name":"たからふじ"}]},
+  {"company":"大野酒造","city":"倉敷市水島連島町", "details":[
+    {"name":"富志美盛","kana_name":"ふしみざかり"}]},
+  {"company":"森田酒造","city":"倉敷市倉敷", "details":[
+    {"name":"萬年雪","kana_name":"まんねんゆき"}]},
+  {"company":"白神酒造","city":"倉敷市", "details":[
+    {"name":"玉司","kana_name":"たまつかさ"}]},
+  {"company":"大内酒造場","city":"笠岡市大島", "details":[
+    {"name":"御嶽鶴","kana_name":"みたけづる"}]},
+  {"company":"長山酒造","city":"笠岡市", "details":[
+    {"name":"大泉","kana_name":"おおいずみ"}]},
+  {"company":"滝本酒造","city":"井原市", "details":[
+    {"name":"一品","kana_name":"いっぴん"}]},
+  {"company":"山成酒造","city":"井原市", "details":[
+    {"name":"蘭の誉","kana_name":"らんのほまれ"}]},
+  {"company":"白菊酒造","city":"高梁市", "details":[
+    {"name":"大典白菊","kana_name":"たいてんしらぎく"}]},
+  {"company":"赤木酒造","city":"高梁市", "details":[
+    {"name":"曲水","kana_name":"きょくすい"},
+    {"name":"蘭亭曲水","kana_name":"らんていきょくすい"}]},
+  {"company":"芳烈酒造","city":"高梁市", "details":[
+    {"name":"桜芳烈","kana_name":"おうほうれつ"}]},
+  {"company":"小出酒造","city":"加賀郡吉備中央町", "details":[
+    {"name":"高雪","kana_name":"たかゆき"}]},
+  {"company":"三光正宗","city":"新見市", "details":[
+    {"name":"三光正宗","kana_name":"さんこうまさむね"}]},
+  {"company":"板野酒造本店","city":"岡山市足守", "details":[
+    {"name":"二面","kana_name":"ふたも"}]},
+  {"company":"利守酒造","city":"赤磐市", "details":[
+    {"name":"酒一筋","kana_name":"さけひとすじ"},
+    {"name":"赤磐雄町","kana_name":"あかいわおまち"},
+    {"name":"南山寿","kana_name":"なんざんじゅ"},
+    {"name":"秘伝","kana_name":"ひでん"},
+    {"name":"天下人","kana_name":"てんかびと"}]},
+  {"company":"宮下酒造","city":"岡山市", "details":[
+    {"name":"極聖","kana_name":"きわみひじり"},
+    {"name":"備前児島酒","kana_name":"びぜんこじまざけ"}]},
+  {"company":"服部本家酒造場","city":"瀬戸内市", "details":[
+    {"name":"折鶴","kana_name":"おりづる"},
+    {"name":"有春","kana_name":"ゆうしゅん"}]},
+  {"company":"小坂酒造","city":"赤磐市", "details":[
+    {"name":"鶴の池","kana_name":"つるのいけ"}]},
+  {"company":"越宗酒造","city":"赤磐市", "details":[
+    {"name":"赤坂錦","kana_name":"あかさかにしき"}]},
+  {"company":"周藤酒造","city":"赤磐市", "details":[
+    {"name":"七福","kana_name":"しちふく"}]},
+  {"company":"赤磐酒造","city":"赤磐市", "details":[
+    {"name":"桃白眉","kana_name":"ももはくび"}]},
+  {"company":"室町酒造","city":"赤磐市", "details":[
+    {"name":"櫻室町","kana_name":"さくらむろまち"}]},
+  {"company":"赤磐酒造","city":"赤磐市", "details":[
+    {"name":"桃白眉","kana_name":"ももはくび"}]},
+  {"company":"小宮山酒造","city":"赤磐市", "details":[
+    {"name":"日月","kana_name":"じつげつ"}]},
+  {"company":"金剛酒造","city":"和気郡和気町", "details":[
+    {"name":"金剛","kana_name":"こんごう"}]},
+  {"company":"玉泉酒造","city":"備前市", "details":[
+    {"name":"玉泉","kana_name":"たまいずみ"}]},
+  {"company":"横山酒造場","city":"備前市", "details":[
+    {"name":"鶴の海","kana_name":"つるのうみ"}]},
+  {"company":"大饗酒造","city":"備前市", "details":[
+    {"name":"吉野鶴","kana_name":"よしのづる"}]},
+  {"company":"高祖酒造","city":"瀬戸内市", "details":[
+    {"name":"千寿","kana_name":"せんじゅ"}]},
+  {"company":"岡崎酒造","city":"岡山市", "details":[
+    {"name":"金翼大鵬","kana_name":"きんよくたいほう"}]},
+  {"company":"小林本店","city":"岡山市", "details":[
+    {"name":"天来","kana_name":"てんらい"}]},
+  {"company":"石原酒造場","city":"岡山市", "details":[
+    {"name":"おそめ","kana_name":""}]},
+  {"company":"お多美鶴酒造","city":"岡山市", "details":[
+    {"name":"お多美鶴","kana_name":"おたみつる"}]},
+  {"company":"萬歳酒造","city":"岡山市", "details":[
+    {"name":"さつき心","kana_name":"さつきこころ"}]},
+  {"company":"板野酒造場","city":"岡山市", "details":[
+    {"name":"きびの吟風","kana_name":"きびのぎんぷう"}]},
+  {"company":"藤原酒造","city":"玉野市", "details":[
+    {"name":"亀乃井","kana_name":"かめのい"}]},
+  {"company":"熊屋酒造","city":"倉敷市児島", "details":[
+    {"name":"巴福正宗","kana_name":"ともえふくまさむね"}]},
+  {"company":"十八盛酒造","city":"倉敷市児島", "details":[
+    {"name":"十八盛","kana_name":"じゅうはちざかり"}]},
+  {"company":"尾崎酒造場","city":"倉敷市児島", "details":[
+    {"name":"雪嵐","kana_name":"ゆきあらし"}]},
+  {"company":"三冠酒造","city":"倉敷市児島", "details":[
+    {"name":"三冠","kana_name":"さんかん"}]},
+  {"company":"放駒酒造","city":"倉敷市児島", "details":[
+    {"name":"放駒","kana_name":"はなれごま"}]},
+  {"company":"永山本家酒造場","city":"倉敷市児島", "details":[
+    {"name":"連山","kana_name":"れんざん"},
+    {"name":"秀峯連山","kana_name":"しゅうほうれんざん"}]},
+  {"company":"岡部銘醸","city":"倉敷市水島福田町", "details":[
+    {"name":"歓酔","kana_name":"かんすい"}]},
+  {"company":"辻本店","city":"真庭市", "details":[
+    {"name":"御前酒","kana_name":"ごぜんしゅ"},
+    {"name":"美作","kana_name":"みまさか"},
+    {"name":"馨","kana_name":"けい"},
+    {"name":"作州","kana_name":"さくしゅう"},
+    {"name":"GOZENSHU 9 NINE","kana_name":"ごぜんしゅ ないん"},
+    {"name":"炭屋彌兵衛","kana_name":"すみや やへえ"}]},
+  {"company":"難波酒造","city":"津山市", "details":[
+    {"name":"富久迎 吟","kana_name":"ふくむかえ ぎん"},
+    {"name":"作州武蔵 荒ばしり","kana_name":"さくしゅう むさし あらばしり"},
+    {"name":"剣聖武蔵","kana_name":"けんせいむさし"},
+    {"name":"津山城 米のしずく","kana_name":"つやまじょう こめのしずく"},
+    {"name":"作州武蔵","kana_name":"さくしゅう むさし"},
+    {"name":"津山城","kana_name":"つやまじょう"},
+    {"name":"大美酒造","kana_name":"真庭市蒜山"},
+    {"name":"美保鶴","kana_name":"みほづる"}]},
+  {"company":"牧野酒造本店","city":"苫田郡鏡野町", "details":[
+    {"name":"五十鈴","kana_name":"いそすず"}]},
+  {"company":"後藤酒造","city":"苫田郡鏡野町", "details":[
+    {"name":"藤娘","kana_name":"ふじむすめ"}]},
+  {"company":"多胡本家酒造場","city":"津山市", "details":[
+    {"name":"加茂五葉","kana_name":"かものいつは"}]},
+  {"company":"東郷酒造","city":"美作市", "details":[
+    {"name":"東郷","kana_name":"とうごう"}]},
+  {"company":"遠藤酒造場","city":"美作市", "details":[
+    {"name":"光露","kana_name":"こうろ"}]},
+  {"company":"山本酒造","city":"美作市", "details":[
+    {"name":"喜久娘","kana_name":"きくむすめ"}]},
+  {"company":"吉野酒造","city":"美作市", "details":[
+    {"name":"牡丹正宗","kana_name":"ぼたんまさむね"}]},
+  {"company":"田中酒造場","city":"美作市大原", "details":[
+    {"name":"武蔵の里","kana_name":"むさしのさと"}]}
+]},
+{"name_n":"広島県","city_r":[
+  {"company":"安佐酒造","city":"広島市安佐南区", "details":[
+    {"name":"安佐泉","kana_name":"あさいずみ"}]},
+  {"company":"福光酒造","city":"山県郡北広島町", "details":[
+    {"name":"朝光","kana_name":"あさひかり"}]},
+  {"company":"中国醸造","city":"廿日市市桜尾", "details":[
+    {"name":"一代","kana_name":"いちだい"}]},
+  {"company":"相原酒造","city":"呉市仁方本町", "details":[
+    {"name":"雨後の月","kana_name":"うごのつき"}]},
+  {"company":"白蘭酒造","city":"", "details":[
+    {"name":"英心","kana_name":"えいしん"}]},
+  {"company":"小野酒造","city":"山県郡北広島町", "details":[
+    {"name":"老亀","kana_name":"おいがめ"}]},
+  {"company":"藤岡酒造店","city":"呉市", "details":[
+    {"name":"音戸の瀬戸","kana_name":"おんどのせと"}]},
+  {"company":"賀茂泉酒造","city":"東広島市西条上市町", "details":[
+    {"name":"賀茂泉","kana_name":"かもいずみ"}]},
+  {"company":"賀茂鶴酒造","city":"東広島市西条本町", "details":[
+    {"name":"賀茂鶴","kana_name":"かもつる"}]},
+  {"company":"柄酒造","city":"東広島市安芸津町", "details":[
+    {"name":"関西一","kana_name":"かんさいいち"}]},
+  {"company":"北村醸造場","city":"庄原市東城町", "details":[
+    {"name":"菊文明","kana_name":"きくぶんめい"}]},
+  {"company":"藤高酒造","city":"大竹市木野", "details":[
+    {"name":"喜久娘","kana_name":"きくむすめ"}]},
+  {"company":"旭鳳酒造","city":"広島市安佐北区", "details":[
+    {"name":"旭鳳","kana_name":"きょくほう"}]},
+  {"company":"亀齡酒造","city":"東広島市西条本町", "details":[
+    {"name":"亀齡","kana_name":"きれい"}]},
+  {"company":"西條鶴醸造","city":"東広島市西条本町", "details":[
+    {"name":"西條鶴","kana_name":"さいじょうつる"},
+    {"name":"天保井水","kana_name":"てんぽういすい"},
+    {"name":"神髄","kana_name":"しんずい"},
+    {"name":"西鶴","kana_name":"さいかく"}]},
+  {"company":"金光酒造","city":"東広島市", "details":[
+    {"name":"桜吹雪","kana_name":"さくらふぶき"}]},
+  {"company":"川本英介","city":"山県郡安芸太田町", "details":[
+    {"name":"三段峡","kana_name":"さんだんきょう"}]},
+  {"company":"板岡酒造場","city":"安芸高田市吉田町", "details":[
+    {"name":"山陽愛泉","kana_name":"さんようあいせん"}]},
+  {"company":"山陽鶴酒造","city":"東広島市西条岡町", "details":[
+    {"name":"山陽鶴","kana_name":"さんようつる"}]},
+  {"company":"津田酒造","city":"江田島市", "details":[
+    {"name":"島の香","kana_name":"しまのかおり"}]},
+  {"company":"吉源酒造場","city":"尾道市三軒家町", "details":[
+    {"name":"寿齢","kana_name":"じゅれい"}]},
+  {"company":"白石酒造","city":"広島市安佐北区", "details":[
+    {"name":"白瀧","kana_name":"しらたき"}]},
+  {"company":"高橋酒造","city":"福山市", "details":[
+    {"name":"深山","kana_name":"しんざん"}]},
+  {"company":"三輪酒造","city":"神石郡神石高原町", "details":[
+    {"name":"神雷","kana_name":"しんらい"}]},
+  {"company":"山岡酒造","city":"三次市", "details":[
+    {"name":"瑞冠","kana_name":"ずいかん"}]},
+  {"company":"酔心山根本店","city":"三原市東町", "details":[
+    {"name":"酔心","kana_name":"すいしん"}]},
+  {"company":"中野光次郎","city":"呉市吉浦中町", "details":[
+    {"name":"水龍","kana_name":"すいりゅう"}]},
+  {"company":"中尾醸造","city":"竹原市中央", "details":[
+    {"name":"誠鏡","kana_name":"せいきょう"}]},
+  {"company":"三宅本店","city":"呉市本通", "details":[
+    {"name":"千福","kana_name":"せんぷく"}]},
+  {"company":"馬上酒造","city":"安芸郡熊野町", "details":[
+    {"name":"大号令","kana_name":"だいごうれい"}]},
+  {"company":"高野山酒造","city":"庄原市", "details":[
+    {"name":"高野山天龍","kana_name":"たかのやまてんりゅう"}]},
+  {"company":"竹鶴酒造","city":"竹原市本町", "details":[
+    {"name":"竹鶴","kana_name":"たけつる"}]},
+  {"company":"生熊酒造","city":"庄原市", "details":[
+    {"name":"超群","kana_name":"ちょうぐん"}]},
+  {"company":"柄商店","city":"東広島市安芸津町", "details":[
+    {"name":"つちや","kana_name":""}]},
+  {"company":"天寶一","city":"福山市", "details":[
+    {"name":"天寶一","kana_name":"てんぽういち"}]},
+  {"company":"江田島銘醸","city":"江田島市江田島町", "details":[
+    {"name":"同期の桜","kana_name":"どうきのさくら"}]},
+  {"company":"入江豊三郎本店","city":"福山市鞆町", "details":[
+    {"name":"トモエ","kana_name":"ともえ"}]},
+  {"company":"盛川酒造","city":"呉市安浦町", "details":[
+    {"name":"白鴻","kana_name":"はくこう"}]},
+  {"company":"白天龍酒造場","city":"呉市警固屋", "details":[
+    {"name":"白天龍","kana_name":"はくてんりゅう"}]},
+  {"company":"白牡丹酒造","city":"東広島市西条本町", "details":[
+    {"name":"白牡丹","kana_name":"はくぼたん"}]},
+  {"company":"白蘭酒造","city":"三次市三次町", "details":[
+    {"name":"白蘭","kana_name":"はくらん"}]},
+  {"company":"榎酒造","city":"呉市", "details":[
+    {"name":"華鳩","kana_name":"はなはと"}]},
+  {"company":"花酔酒造","city":"庄原市", "details":[
+    {"name":"花酔","kana_name":"はなよい"}]},
+  {"company":"久保田酒造","city":"広島市安佐北区", "details":[
+    {"name":"菱正宗","kana_name":"ひしまさむね"}]},
+  {"company":"比婆美人酒造","city":"庄原市三日市町", "details":[
+    {"name":"比婆美人","kana_name":"ひばびじん"}]},
+  {"company":"今田酒造本店","city":"東広島市", "details":[
+    {"name":"富久長","kana_name":"ふくちょう"}]},
+  {"company":"福美人酒造","city":"東広島市西条本町", "details":[
+    {"name":"福美人","kana_name":"ふくびじん"}]},
+  {"company":"福六酒造","city":"三次市", "details":[
+    {"name":"福六","kana_name":"ふくろく"}]},
+  {"company":"相原本店","city":"呉市仁方本町", "details":[
+    {"name":"不二寿","kana_name":"ふじことぶき"}]},
+  {"company":"田熊酒造","city":"大竹市元町", "details":[
+    {"name":"宝永鶴","kana_name":"ほうえいづる"}]},
+  {"company":"宝剣酒造","city":"呉市仁方本町", "details":[
+    {"name":"宝剣","kana_name":"ほうけん"}]},
+  {"company":"藤井酒造","city":"竹原市本町", "details":[
+    {"name":"宝寿","kana_name":"ほうじゅ"},
+    {"name":"龍勢","kana_name":"りゅうせい"},
+    {"name":"夜の帝王","kana_name":"よるのていおう"},
+    {"name":"三人文殊","kana_name":"さんにんもんじゅ"}]},
+  {"company":"原本店","city":"広島市中区", "details":[
+    {"name":"蓬莱鶴","kana_name":"ほうらいつる"}]},
+  {"company":"梅田酒造場","city":"広島市安芸区", "details":[
+    {"name":"本州一","kana_name":"ほんしゅういち"}]},
+  {"company":"林酒造","city":"呉市", "details":[
+    {"name":"三谷春","kana_name":"みたにはる"}]},
+  {"company":"佐藤酒造","city":"呉市中央", "details":[
+    {"name":"満潮","kana_name":"みちしお"}]},
+  {"company":"岡本亀太郎本店","city":"福山市", "details":[
+    {"name":"ミツボシ","kana_name":"みつぼし"}]},
+  {"company":"八谷酒造","city":"庄原市峰田町", "details":[
+    {"name":"峰仙人","kana_name":"みねせんにん"}]},
+  {"company":"美の鶴酒造","city":"深安郡", "details":[
+    {"name":"美の鶴","kana_name":"みのつる"}]},
+  {"company":"小泉本店","city":"広島市西区", "details":[
+    {"name":"御幸","kana_name":"みゆき"}]},
+  {"company":"アシードブリュー","city":"福山市箕島町", "details":[
+    {"name":"三吉正宗","kana_name":"みよしまさむね"}]},
+  {"company":"美和桜酒造","city":"三次市", "details":[
+    {"name":"美和桜","kana_name":"みわさくら"}]},
+  {"company":"向原酒造","city":"安芸高田市向原町", "details":[
+    {"name":"向井桜","kana_name":"むかいざくら"}]},
+  {"company":"上杉酒造","city":"山県郡北広島町", "details":[
+    {"name":"八重の露","kana_name":"やえのつゆ"}]},
+  {"company":"八幡川酒造","city":"広島市佐伯区", "details":[
+    {"name":"八幡川","kana_name":"やはたかわ"}]}
+]},
+{"name_n":"山口県","city_r":[
+  {"company":"一〇酒造","city":"萩市", "details":[
+    {"name":"一〇正宗","kana_name":"いちまるまさむね"}]},
+  {"company":"八百新酒造","city":"岩国市", "details":[
+    {"name":"雁木","kana_name":"がんぎ"}]},
+  {"company":"村重酒造","city":"岩国市", "details":[
+    {"name":"金冠黒松","kana_name":"きんかんくろまつ"}]},
+  {"company":"酒井酒造","city":"岩国市", "details":[
+    {"name":"五橋","kana_name":"ごきょう"}]},
+  {"company":"金光酒造","city":"山口市", "details":[
+    {"name":"山頭火","kana_name":"さんとうか"}]},
+  {"company":"中村酒造","city":"萩市", "details":[
+    {"name":"宝船","kana_name":"たからぶね"}]},
+  {"company":"永山本家酒造場","city":"宇部市", "details":[
+    {"name":"貴","kana_name":"たか"}]},
+  {"company":"旭酒造","city":"岩国市", "details":[
+    {"name":"獺祭","kana_name":"だっさい"}]},
+  {"company":"岡崎酒造場","city":"萩市", "details":[
+    {"name":"長門峡","kana_name":"ちょうもんきょう"}]},
+  {"company":"岩崎酒造","city":"萩市", "details":[
+    {"name":"長陽福娘","kana_name":"ちょうようふくむすめ"}]},
+  {"company":"澄川酒造場","city":"萩市", "details":[
+    {"name":"東洋美人","kana_name":"とうようびじん"}]},
+  {"company":"下関酒造","city":"下関市", "details":[
+    {"name":"関娘","kana_name":"せきむすめ"}]}
+]},
+{"name_n":"徳島県","city_r":[
+  {"company":"太閤酒造場","city":"阿波市", "details":[
+    {"name":"瓢太閤","kana_name":"ひさごたいこう"},
+    {"name":"辛口新酒","kana_name":"からくちしんしゅ"},
+    {"name":"我流","kana_name":"がりゅう"},
+    {"name":"錦竜水","kana_name":"きんりょうすい"}]},
+  {"company":"本家松浦酒造場","city":"鳴門市", "details":[
+    {"name":"鳴門鯛","kana_name":"なるとだい"}]},
+  {"company":"三芳菊酒造","city":"三好市", "details":[
+    {"name":"三芳菊","kana_name":"みよしきく"}]},
+  {"company":"芳水酒造","city":"三好市", "details":[
+    {"name":"芳水","kana_name":"ほうすい"}]},
+  {"company":"津乃峰酒造","city":"阿南市", "details":[
+    {"name":"津乃峰","kana_name":"つのみね"}]},
+  {"company":"吉本醸造","city":"徳島市", "details":[
+    {"name":"南国一","kana_name":"なんごくいち"}]},
+  {"company":"斎藤酒造場","city":"徳島市", "details":[
+    {"name":"御殿桜","kana_name":"ごてんざくら"}]},
+  {"company":"近清酒造","city":"阿南市", "details":[
+    {"name":"入鶴","kana_name":"いりづる"}]},
+  {"company":"花乃春酒造","city":"鳴門市", "details":[
+    {"name":"花乃春","kana_name":"はなのはる"}]},
+  {"company":"（名）中和商店","city":"三好市", "details":[
+    {"name":"今小町","kana_name":"いまこまち"}]},
+  {"company":"勢玉","city":"徳島市", "details":[
+    {"name":"勢玉","kana_name":"せいぎょく"}]},
+  {"company":"近藤松太郎商店","city":"徳島市", "details":[
+    {"name":"旭牡丹","kana_name":"あさひぼたん"}]},
+  {"company":"名西酒造","city":"神山町", "details":[
+    {"name":"白妙","kana_name":"しろたえ"}]},
+  {"company":"定作酒類醸造場","city":"勝浦町", "details":[
+    {"name":"桂花","kana_name":"けいか"}]},
+  {"company":"吉田酒造","city":"徳島市", "details":[
+    {"name":"蘭玉","kana_name":"らんぎょく"}]},
+  {"company":"那賀酒造","city":"那賀町", "details":[
+    {"name":"旭若松","kana_name":"あさひわかまつ"}]},
+  {"company":"三拍子酒造","city":"鳴門市", "details":[
+    {"name":"三拍子","kana_name":"さんびょうし"}]},
+  {"company":"鳴門酒造","city":"鳴門市", "details":[
+    {"name":"円滑","kana_name":"えんかつ"}]},
+  {"company":"木内本店","city":"藍住町", "details":[
+    {"name":"雲井橘","kana_name":"くもいたちばな"}]},
+  {"company":"徳島金長","city":"上板町", "details":[
+    {"name":"四国三郎","kana_name":"しこくさぶろう"}]},
+  {"company":"鳴門酒造協同組合","city":"鳴門市", "details":[
+    {"name":"大鳴門","kana_name":"おおなると"}]},
+  {"company":"伊勢酒造","city":"吉野川市", "details":[
+    {"name":"四国鶴","kana_name":"しこくづる"}]},
+  {"company":"大賀酒造","city":"美馬市", "details":[
+    {"name":"富士の雪","kana_name":"ふじのゆき"}]},
+  {"company":"明星酒造","city":"美馬市", "details":[
+    {"name":"阿波鶴","kana_name":"あわづる"}]},
+  {"company":"四宮酒造","city":"美馬市", "details":[
+    {"name":"剣鯛","kana_name":"つるぎだい"}]},
+  {"company":"阿川酒造","city":"つるぎ町", "details":[
+    {"name":"齢の友","kana_name":"よわいのとも"}]},
+  {"company":"司菊酒造","city":"美馬市", "details":[
+    {"name":"司菊","kana_name":"つかさぎく"}]},
+  {"company":"矢川酒造","city":"三好市", "details":[
+    {"name":"笹緑","kana_name":"ささみどり"}]},
+  {"company":"可楽智酒造","city":"東みよし町", "details":[
+    {"name":"可楽智","kana_name":"からち"}]},
+  {"company":"高鉾建設 酒販事業部","city":"上勝町", "details":[
+    {"name":"上勝の棚田米と湧き水と負けん気でこっしゃえた","kana_name":""}]}
+]},
+{"name_n":"香川県","city_r":[
+  {"company":"綾菊酒造","city":"綾歌郡綾川町", "details":[
+    {"name":"綾菊","kana_name":"あやきく"}]},
+  {"company":"川鶴酒造","city":"観音寺市", "details":[
+    {"name":"川鶴","kana_name":"かわつる"}]},
+  {"company":"有限会社 丸尾本店","city":"琴平町", "details":[
+    {"name":"悦凱陣","kana_name":"よろこびがいじん"}]},
+  {"company":"西野金陵酒造","city":"高松市", "details":[
+    {"name":"金陵","kana_name":"きんりょう"}]},
+  {"company":"岡田酒造","city":"丸亀市", "details":[
+    {"name":"さぬきのにごり酒","kana_name":"さぬきのにごりざけ"}]},
+  {"company":"森国酒造","city":"小豆郡小豆島町", "details":[
+    {"name":"森","kana_name":"もり"},
+    {"name":"田の神","kana_name":"たのかみ"},
+    {"name":"風画","kana_name":"ふうが"},
+    {"name":"酒翁","kana_name":"しゅおう"},
+    {"name":"ふわふわ","kana_name":"ふわふわ"},
+    {"name":"ふふふ","kana_name":"ふふふ"},
+    {"name":"うとうと","kana_name":"うとうと"},
+    {"name":"びびび","kana_name":"びびび"}]}
+]},
+{"name_n":"愛媛県","city_r":[
+  {"company":"梅錦山川","city":"四国中央市", "details":[
+    {"name":"梅錦","kana_name":"うめにしき"}]},
+  {"company":"篠永酒造","city":"四国中央市", "details":[
+    {"name":"森の翠","kana_name":"もりのみどり"}]},
+  {"company":"協和酒造","city":"伊予郡砥部町", "details":[
+    {"name":"初雪盃","kana_name":"はつゆきはい"}]},
+  {"company":"徳本酒造合名会社","city":"伊予市", "details":[
+    {"name":"初鷹","kana_name":"はつたか"},
+    {"name":"五色姫","kana_name":"ごしきひめ"}]},
+  {"company":"武田酒造","city":"西条市", "details":[
+    {"name":"日本心","kana_name":"やまとごころ"},
+    {"name":"助六","kana_name":"すけろく"},
+    {"name":"なでしこ","kana_name":"なでしこ"},
+    {"name":"プラス嗜好","kana_name":"ぷらすしこう"},
+    {"name":"伊方杜氏の誌","kana_name":"いかたとうじのうた"},
+    {"name":"瑠璃","kana_name":"るり"}]},
+  {"company":"西本酒造","city":"宇和島市", "details":[
+    {"name":"大番","kana_name":"おおばん"},
+    {"name":"え","kana_name":"え"},
+    {"name":"虎の尾","kana_name":"とらのお"}]},
+  {"company":"千代の亀酒造","city":"喜多郡内子町", "details":[
+    {"name":"銀河鉄道","kana_name":"ぎんがてつどう"},
+    {"name":"秘蔵しずく酒","kana_name":"ひぞうしずくしゅ"}]}
+]},
+{"name_n":"高知県","city_r":[
+  {"company":"司牡丹酒造","city":"高岡郡佐川町", "details":[
+    {"name":"司牡丹","kana_name":"つかさぼたん"}]},
+  {"company":"土佐鶴酒造","city":"安芸郡安田町", "details":[
+    {"name":"土佐鶴","kana_name":"とさづる"},
+    {"name":"azure","kana_name":"あじゅーる"},
+    {"name":"土佐宇宙酒","kana_name":"とさうちゅうしゅ"}]},
+  {"company":"酔鯨酒造","city":"高知市", "details":[
+    {"name":"酔鯨","kana_name":"すいげい"},
+    {"name":"山内家ゆかりの酒","kana_name":"やまうちけゆかりのさけ"}]},
+  {"company":"亀泉酒造","city":"土佐市", "details":[
+    {"name":"亀泉","kana_name":"かめいずみ"},
+    {"name":"酒家長春萬寿亀泉","kana_name":"しゅかちょうしゅんまんじゅ かめいずみ"},
+    {"name":"土佐のいごっそう","kana_name":"とさのいごっそう"},
+    {"name":"デリッ酒","kana_name":"でりっしゅ"}]},
+  {"company":"濱川商店","city":"安芸郡田野町", "details":[
+    {"name":"美丈夫","kana_name":"びじょうふ"},
+    {"name":"濱乃鶴","kana_name":"はまのつる"},
+    {"name":"慎太郎","kana_name":"しんたろう"}]},
+  {"company":"南酒造場","city":"安芸郡安田町", "details":[
+    {"name":"南","kana_name":"みなみ"}]},
+  {"company":"菊水酒造","city":"安芸市", "details":[
+    {"name":"菊水","kana_name":"きくすい"},
+    {"name":"四万十川","kana_name":"しまんとがわ"},
+    {"name":"龍馬","kana_name":"りょうま"}]},
+  {"company":"有光酒造場","city":"安芸市", "details":[
+    {"name":"安芸虎","kana_name":"あきとら"},
+    {"name":"赤野","kana_name":"あかの"},
+    {"name":"玉川","kana_name":"たまがわ"}]},
+  {"company":"仙頭酒造場","city":"安芸郡芸西村", "details":[
+    {"name":"しらぎく","kana_name":"しらぎく"}]},
+  {"company":"高木酒造","city":"香南市", "details":[
+    {"name":"豊の梅","kana_name":"とよのうめ"}]},
+  {"company":"アリサワ","city":"香美市", "details":[
+    {"name":"文佳人","kana_name":"ぶんかじん"},
+    {"name":"鳴子舞","kana_name":"なるこまい"},
+    {"name":"鏡野","kana_name":"かがみの"}]},
+  {"company":"松尾酒造","city":"香美市", "details":[
+    {"name":"松翁","kana_name":"まつおきな"},
+    {"name":"土陽正宗","kana_name":"どようまさむね"},
+    {"name":"山田太鼓","kana_name":"やまだだいこ"}]},
+  {"company":"高知酒造","city":"吾川郡いの町", "details":[
+    {"name":"瀧嵐","kana_name":"たきあらし"}]},
+  {"company":"西岡酒造店","city":"高岡郡中土佐町", "details":[
+    {"name":"純平","kana_name":"じゅんぺい"},
+    {"name":"雪柳","kana_name":"ゆきやなぎ"},
+    {"name":"大飲み村","kana_name":"おおのみむら"},
+    {"name":"久礼","kana_name":"くれ"},
+    {"name":"土佐一","kana_name":"とさいち"}]},
+  {"company":"文本酒造","city":"高岡郡四万十町", "details":[
+    {"name":"桃太郎","kana_name":"ももたろう"},
+    {"name":"フレッシュ入駒","kana_name":""}]},
+  {"company":"無手無冠","city":"高岡郡四万十町", "details":[
+    {"name":"無手無冠","kana_name":"むてむか"},
+    {"name":"千代登","kana_name":"ちよのぼり"},
+    {"name":"火詰五番","kana_name":"ひづめごばん"},
+    {"name":"だれやすけ","kana_name":"だれやすけ"},
+    {"name":"生三番","kana_name":"なまさんばん"},
+    {"name":"鬼辛","kana_name":"おにから"}]}
+]},
+{"name_n":"福岡県","city_r":[
+  {"company":"旭菊酒造","city":"久留米市", "details":[
+    {"name":"旭菊","kana_name":"あさひぎく"}]},
+  {"company":"旭松酒造","city":"八女市", "details":[
+    {"name":"旭松","kana_name":"あさひまつ"}]},
+  {"company":"江頭酒造","city":"大牟田市", "details":[
+    {"name":"旭盛","kana_name":"あさひもり"}]},
+  {"company":"綾杉酒造場","city":"福岡市南区", "details":[
+    {"name":"綾杉","kana_name":"あやすぎ"}]},
+  {"company":"池田屋","city":"みやま市", "details":[
+    {"name":"池泉","kana_name":"いけいずみ"}]},
+  {"company":"いそのさわ","city":"うきは市", "details":[
+    {"name":"磯乃澤","kana_name":"いそのさわ"}]},
+  {"company":"梅ヶ谷酒造","city":"嘉麻市", "details":[
+    {"name":"梅ヶ谷","kana_name":"うめがたに"}]},
+  {"company":"伊豆本店","city":"宗像市", "details":[
+    {"name":"亀の尾","kana_name":"かめのお"}]},
+  {"company":"玉の井酒造","city":"嘉麻市", "details":[
+    {"name":"寒北斗","kana_name":"かんほくと"}]},
+  {"company":"菊美人酒造","city":"みやま市", "details":[
+    {"name":"菊美人","kana_name":"きくびじん"}]},
+  {"company":"喜多屋","city":"八女市", "details":[
+    {"name":"喜多屋","kana_name":"きたや"},
+    {"name":"寒山水","kana_name":"かんさんすい"}]},
+  {"company":"林平作酒造","city":"京都郡みやこ町", "details":[
+    {"name":"九州菊","kana_name":"くすぎく"}]},
+  {"company":"株式会社篠崎","city":"朝倉市", "details":[
+    {"name":"国菊","kana_name":"くにぎく"}]},
+  {"company":"清力酒造","city":"大川市", "details":[
+    {"name":"蔵談義","kana_name":"くらだんぎ"}]},
+  {"company":"杜の蔵","city":"久留米市", "details":[
+    {"name":"黒田城 大手門","kana_name":"くろだじょう おおてもん"}]},
+  {"company":"大里酒造","city":"嘉麻市", "details":[
+    {"name":"黒田武士","kana_name":"くろだぶし"}]},
+  {"company":"薫仙","city":"嘉麻市", "details":[
+    {"name":"薫仙","kana_name":"くんせん"}]},
+  {"company":"高橋商店","city":"八女市", "details":[
+    {"name":"繁桝","kana_name":"しげます"}]},
+  {"company":"石蔵酒造","city":"福岡市博多区", "details":[
+    {"name":"如水","kana_name":"じょすい"}]},
+  {"company":"白糸酒造","city":"糸島市", "details":[
+    {"name":"白糸","kana_name":"しらいと"}]},
+  {"company":"よろずや酒造","city":"田川郡添田町", "details":[
+    {"name":"酒仙の泉","kana_name":"しゅせんのいずみ"}]},
+  {"company":"浜地酒造","city":"福岡市西区", "details":[
+    {"name":"杉能舎","kana_name":"すぎのや"}]},
+  {"company":"園乃蝶酒造","city":"みやま市", "details":[
+    {"name":"園乃蝶","kana_name":"そののちょう"}]},
+  {"company":"翁酒造","city":"古賀市", "details":[
+    {"name":"大観","kana_name":"たいかん"}]},
+  {"company":"鷹正宗","city":"久留米市", "details":[
+    {"name":"鷹正宗","kana_name":"たかまさむね"}]},
+  {"company":"大賀酒造","city":"筑紫野市", "details":[
+    {"name":"玉出泉","kana_name":"たまでいずみ"}]},
+  {"company":"玉水酒造","city":"みやま市", "details":[
+    {"name":"玉水","kana_name":"たまみず"}]},
+  {"company":"筑紫の誉酒造","city":"久留米市", "details":[
+    {"name":"筑紫の誉","kana_name":"ちくしのほまれ"}]},
+  {"company":"千年乃松酒造","city":"久留米市", "details":[
+    {"name":"千年乃松","kana_name":"ちとせのまつ"}]},
+  {"company":"野田酒造","city":"みやま市", "details":[
+    {"name":"千代錦","kana_name":"ちよにしき"}]},
+  {"company":"森山酒造","city":"小郡市", "details":[
+    {"name":"月の桂","kana_name":"つきのかつら"}]},
+  {"company":"溝上酒造","city":"北九州市八幡東区", "details":[
+    {"name":"天心","kana_name":"てんしん"}]},
+  {"company":"豊村酒造","city":"福津市", "details":[
+    {"name":"豊盛","kana_name":"とよさかり"}]},
+  {"company":"戸渡酒造","city":"田川郡添田町", "details":[
+    {"name":"豊駒","kana_name":"とよこま"}]},
+  {"company":"勝屋酒造","city":"宗像市", "details":[
+    {"name":"楢の露","kana_name":"ならのつゆ"}]},
+  {"company":"光酒造","city":"糟屋郡粕屋町", "details":[
+    {"name":"西の蔵","kana_name":"にしのくら"}]},
+  {"company":"山口酒造場","city":"久留米市", "details":[
+    {"name":"庭のうぐいす","kana_name":"にわのうぐいす"}]},
+  {"company":"花関酒造","city":"太宰府市", "details":[
+    {"name":"花の関","kana_name":"はなのせき"}]},
+  {"company":"冨安本家酒造","city":"久留米市", "details":[
+    {"name":"花の露","kana_name":"はなのつゆ"}]},
+  {"company":"福島酒造","city":"八女市", "details":[
+    {"name":"花宗","kana_name":"はなむね"}]},
+  {"company":"小林酒造本店","city":"糟屋郡宇美町", "details":[
+    {"name":"萬代","kana_name":"ばんだい"}]},
+  {"company":"比翼鶴酒造","city":"久留米市", "details":[
+    {"name":"比翼鶴","kana_name":"ひよくつる"}]},
+  {"company":"飛龍酒造","city":"三井郡大刀洗町", "details":[
+    {"name":"飛龍","kana_name":"ひりゅう"}]},
+  {"company":"石井産業","city":"宮若市", "details":[
+    {"name":"富久鶴","kana_name":"ふくつる"}]},
+  {"company":"福徳長酒類","city":"久留米市", "details":[
+    {"name":"福徳長","kana_name":"ふくとくちょう"}]},
+  {"company":"後藤酒造場","city":"八女市", "details":[
+    {"name":"藤娘","kana_name":"ふじむすめ"}]},
+  {"company":"山口","city":"久留米市", "details":[
+    {"name":"万作","kana_name":"まんさく"}]},
+  {"company":"萬年亀酒造","city":"久留米市", "details":[
+    {"name":"萬年亀","kana_name":"まんねんかめ"}]},
+  {"company":"井上","city":"三井郡大刀洗町", "details":[
+    {"name":"三井の寿","kana_name":"みいのことぶき"}]},
+  {"company":"瑞穂菊酒造","city":"飯塚市", "details":[
+    {"name":"瑞穂菊","kana_name":"みずほぎく"}]},
+  {"company":"無法松酒造","city":"北九州市小倉南区", "details":[
+    {"name":"無法松","kana_name":"むほうまつ"}]},
+  {"company":"有薫酒造","city":"久留米市", "details":[
+    {"name":"有薫","kana_name":"ゆうくん"}]},
+  {"company":"若竹屋酒造場","city":"久留米市", "details":[
+    {"name":"若竹屋","kana_name":"わかたけや"}]},
+  {"company":"若波酒造","city":"大川市", "details":[
+    {"name":"若波","kana_name":"わかなみ"}]}
+]},
+{"name_n":"佐賀県","city_r":[
+  {"company":"峰松酒造場","city":"鹿島市", "details":[
+    {"name":"菊王将","kana_name":"きくおうしょう"},
+    {"name":"肥前浜宿","kana_name":"ひぜんはましゅく"}]},
+  {"company":"光武酒造場","city":"鹿島市", "details":[
+    {"name":"金波","kana_name":"きんぱ"},
+    {"name":"光武","kana_name":"みつたけ"}]},
+  {"company":"幸姫酒造","city":"鹿島市", "details":[
+    {"name":"幸姫","kana_name":"さちひめ"}]},
+  {"company":"矢野酒造","city":"鹿島市", "details":[
+    {"name":"竹の園","kana_name":"たけのその"},
+    {"name":"肥前蔵心","kana_name":"ひぜんくらごころ"}]},
+  {"company":"富久千代酒造","city":"鹿島市", "details":[
+    {"name":"鍋島","kana_name":"なべしま"},
+    {"name":"富久千代","kana_name":"ふくちよ"}]},
+  {"company":"馬場酒造場","city":"鹿島市", "details":[
+    {"name":"能古見","kana_name":"のごみ"}]},
+  {"company":"古伊万里酒造","city":"伊万里市", "details":[
+    {"name":"古伊万里","kana_name":"こいまり"},
+    {"name":"古伊万里 前","kana_name":"こいまり さき"}]},
+  {"company":"松浦一酒造","city":"伊万里市", "details":[
+    {"name":"松浦一","kana_name":"まつうらいち"},
+    {"name":"いすい","kana_name":"いすい"},
+    {"name":"三酔","kana_name":"さんすい"},
+    {"name":"誠","kana_name":"まこと"}]},
+  {"company":"川浪酒造","city":"伊万里市", "details":[
+    {"name":"富士の雪","kana_name":"ふじのゆき"}]},
+  {"company":"宗政酒造","city":"伊万里市", "details":[
+    {"name":"宗政","kana_name":"むねまさ"}]},
+  {"company":"樋渡酒造場","city":"伊万里市", "details":[
+    {"name":"万里長","kana_name":"まりちょう"}]},
+  {"company":"田中酒造合名会社","city":"伊万里市", "details":[
+    {"name":"弓取","kana_name":"ゆみとり"}]},
+  {"company":"大和酒造","city":"佐賀市", "details":[
+    {"name":"肥前杜氏","kana_name":"ひぜんとうじ"},
+    {"name":"あかかべ","kana_name":"あかかべ"},
+    {"name":"窓の月","kana_name":"まどのつき"},
+    {"name":"佐賀の穣","kana_name":""},
+    {"name":"しめ縄","kana_name":"しめなわ"},
+    {"name":"春の海","kana_name":"はるのうみ"},
+    {"name":"芙蓉","kana_name":"ふよう"}]},
+  {"company":"小柳酒造","city":"小城市", "details":[
+    {"name":"高砂","kana_name":"たかさご"},
+    {"name":"金漿","kana_name":"きんしょう"}]},
+  {"company":"天山酒造","city":"小城市", "details":[
+    {"name":"天山","kana_name":"てんざん"},
+    {"name":"七田","kana_name":"しちだ"}]},
+  {"company":"鳴滝酒造","city":"唐津市", "details":[
+    {"name":"聚楽太閤","kana_name":"じゅらくたいこう"}]},
+  {"company":"小松酒造","city":"唐津市", "details":[
+    {"name":"万齢","kana_name":"まんれい"}]},
+  {"company":"井手酒造","city":"嬉野市", "details":[
+    {"name":"虎之児","kana_name":"とらのこ"}]},
+  {"company":"瀬頭酒造","city":"嬉野市", "details":[
+    {"name":"東長","kana_name":"あづまちょう"}]},
+  {"company":"五町田酒造","city":"嬉野市", "details":[
+    {"name":"東一","kana_name":"あづまいち"}]},
+  {"company":"中島酒造","city":"杵島郡江北町", "details":[
+    {"name":"不老長寿","kana_name":"ふろうちょうじゅ"}]},
+  {"company":"吉武酒造","city":"佐賀市", "details":[
+    {"name":"御宴","kana_name":"ぎょえん"}]},
+  {"company":"窓乃梅酒造","city":"佐賀市", "details":[
+    {"name":"窓乃梅","kana_name":"まどのうめ"},
+    {"name":"八代 文左衛門","kana_name":"はちだい ぶんざえもん"}]},
+  {"company":"天吹酒造","city":"三養基郡みやき町", "details":[
+    {"name":"天吹","kana_name":"あまぶき"}]},
+  {"company":"基山商店","city":"三養基郡基山町", "details":[
+    {"name":"基峰鶴","kana_name":"きほうつる"}]},
+  {"company":"松尾酒造場","city":"西松浦郡有田町", "details":[
+    {"name":"宮の松","kana_name":"みやのまつ"}]},
+  {"company":"東鶴酒造","city":"多久市", "details":[
+    {"name":"東鶴","kana_name":"あづまつる"}]}
+]},
+{"name_n":"長崎県","city_r":[
+  {"company":"河内酒造","city":"対馬市", "details":[
+    {"name":"白嶽","kana_name":"しらたけ"}]},
+  {"company":"福田酒造","city":"平戸市", "details":[
+    {"name":"福鶴","kana_name":"ふくつる"},
+    {"name":"磨法の泉","kana_name":"まほうのいずみ"},
+    {"name":"長崎美人","kana_name":"ながさきびじん"},
+    {"name":"長崎丸山","kana_name":"ながさきまるやま"},
+    {"name":"ギヤマン","kana_name":"ぎやまん"},
+    {"name":"冷水岳","kana_name":"ひやみずだけ"}]},
+  {"company":"杵の川酒造","city":"諫早市", "details":[
+    {"name":"杵の川","kana_name":"きのかわ"},
+    {"name":"黎明","kana_name":"れいめい"},
+    {"name":"恵美福","kana_name":"えみふく"},
+    {"name":"長崎奉行","kana_name":"ながさきぶぎょう"},
+    {"name":"丁子屋","kana_name":"ちょうじや"},
+    {"name":"ほの香","kana_name":"ほのか"},
+    {"name":"雲仙","kana_name":"うんぜん"},
+    {"name":"出島の夢","kana_name":"でじまのゆめ"},
+    {"name":"夢きらめき","kana_name":"ゆめきらめき"},
+    {"name":"長崎阿蘭陀物語","kana_name":"ながさきおらんだものがたり"},
+    {"name":"呉竹","kana_name":"くれたけ"},
+    {"name":"純忠公","kana_name":"すみただこう"},
+    {"name":"ささめ雪","kana_name":"ささめゆき"},
+    {"name":"太陽ささめ雪","kana_name":"たいようささめゆき"},
+    {"name":"祝えびす","kana_name":""}]},
+  {"company":"加藤酒造場","city":"島原市", "details":[
+    {"name":"あさひ登","kana_name":"あさひのぼる"}]}
+]},
+{"name_n":"熊本県","city_r":[
+  {"company":"熊本県酒造研究所 協会9号酵母発祥の蔵","city":"熊本市", "details":[
+    {"name":"香露","kana_name":"こうろ"}]},
+  {"company":"瑞鷹","city":"熊本市", "details":[
+    {"name":"瑞鷹","kana_name":"ずいよう"}]},
+  {"company":"美少年","city":"熊本市", "details":[
+    {"name":"美少年","kana_name":"びしょうねん"},
+    {"name":"宵美人","kana_name":"よいびじん"}]},
+  {"company":"千代の園酒造","city":"山鹿市", "details":[
+    {"name":"千代の園","kana_name":"ちよのその"},
+    {"name":"朱盃","kana_name":"しゅはい"}]},
+  {"company":"亀萬酒造","city":"葦北郡津奈木町", "details":[
+    {"name":"亀萬","kana_name":"かめまん"}]}
+]},
+{"name_n":"大分県","city_r":[
+  {"company":"倉光酒造","city":"大分市", "details":[
+    {"name":"倉光","kana_name":"そうこう"}]},
+  {"company":"老松酒造","city":"日田市", "details":[
+    {"name":"黒鬼","kana_name":""}]},
+  {"company":"クンチョウ酒造","city":"日田市", "details":[
+    {"name":"薫長","kana_name":"くんちょう"},
+    {"name":"遊然","kana_name":"ゆうぜん"}]},
+  {"company":"萱島酒造","city":"国東市", "details":[
+    {"name":"西の関","kana_name":"にしのせき"}]},
+  {"company":"小掠酒造","city":"佐伯市", "details":[
+    {"name":"弥生","kana_name":"やよい"},
+    {"name":"ととろのお酒","kana_name":"ととろのおさけ"}]},
+  {"company":"小松酒造場","city":"宇佐市", "details":[
+    {"name":"豊潤","kana_name":"ほうじゅん"},
+    {"name":"勲の松","kana_name":"いさおのまつ"}]},
+  {"company":"三和酒類","city":"宇佐市", "details":[
+    {"name":"福貴野","kana_name":"ふきの"},
+    {"name":"和香牡丹","kana_name":"わかぼたん"}]},
+  {"company":"久家本店","city":"臼杵市", "details":[
+    {"name":"一の井手","kana_name":"いちのいで"},
+    {"name":"幸の一滴","kana_name":"しずく"}]},
+  {"company":"八鹿酒造","city":"九重町", "details":[
+    {"name":"八鹿","kana_name":"やつしか"},
+    {"name":"ゆふいんの森","kana_name":"ゆふいんのもり"}]}
+]},
+{"name_n":"宮崎県","city_r":[
+  {"company":"雲海酒造","city":"宮崎市", "details":[
+    {"name":"綾錦","kana_name":"あやにしき"}]},
+  {"company":"千徳酒造","city":"延岡市", "details":[
+    {"name":"千徳","kana_name":"せんとく"},
+    {"name":"日向桜","kana_name":"ひゅうがざくら"}]}
+]},
+{"name_n":"鹿児島県","city_r":[
+  {"company":"濱田酒造","city":"いちき串木野市", "details":[
+    {"name":"薩州正宗","kana_name":"さっしゅうまさむね"}]}
+]},
+{"name_n":"沖縄県","city_r":[
+  {"company":"泰石酒造","city":"うるま市", "details":[
+    {"name":"黎明","kana_name":"れいめい"}]}
+]}
+]

--- a/test/controllers/omniauth_callbacks_controller_test.rb
+++ b/test/controllers/omniauth_callbacks_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class OmniauthCallbacksControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/controllers/post_controller_test.rb
+++ b/test/controllers/post_controller_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+class PostControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get post_index_url
+    assert_response :success
+  end
+
+  test "should get show" do
+    get post_show_url
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get post_edit_url
+    assert_response :success
+  end
+
+end

--- a/test/controllers/top_controller_test.rb
+++ b/test/controllers/top_controller_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class TopControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get top_index_url
+    assert_response :success
+  end
+
+end

--- a/test/fixtures/posts.yml
+++ b/test/fixtures/posts.yml
@@ -1,0 +1,15 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  campany: MyString
+  city: MyString
+  sake_name: MyString
+  kana_name: MyString
+
+two:
+  name: MyString
+  campany: MyString
+  city: MyString
+  sake_name: MyString
+  kana_name: MyString

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class PostTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class UserTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
 `/about`はRakuten APIのテスト
  - 商品の名前、画像、URL、値段を取得。

`sake.json`はwikiを参照

モデル`Post`に`name`（都道府県）、`company`（製造会社）、`sake_name`（酒の名前）、`kana_name`（酒のふりがな）を追加

`gem devise`の追加
  - Twitterで認証可能
  - その他の機能は今後調整

スタイルは`bootstrap`を採用